### PR TITLE
docs(workflow): document auto-merge flow for maintainer PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,10 @@ Some files need Discussion/Issue agreement before a PR — see the Scope boundar
 2. `git diff` — eyeball every changed line.
 3. Conventional commit message.
 4. Push your branch; open a PR using the template.
-5. Open the diff on GitHub and verify Mermaid / markdown renders correctly.
+5. Enable auto-merge on the PR:
+   `gh pr merge --auto --squash --delete-branch`.
+   The maintainer's repo setting `allow_auto_merge: true` combined with no branch protection on `main` means the PR merges within seconds of opening, without requiring a human click. For contributor PRs that need review, the maintainer can add `--auto` manually after approving.
+6. Open the merged commit on GitHub and verify Mermaid / markdown rendered correctly. Any leak or render bug after merge means a follow-up commit — amending never fully erases a public mistake.
 
 ## Tone
 


### PR DESCRIPTION
## Summary

Enable the documented zero-touch merge flow for maintainer-opened PRs.

## What changed at the repo level

- `allow_auto_merge: true` enabled via GitHub API (was `false`).
- No branch protection on `main` (unchanged) — so once a PR has auto-merge enabled, it merges within seconds without a human click.

## What changed in the docs

`CLAUDE.md` "Before you push" step 5 now specifies the `gh pr merge --auto --squash --delete-branch` flow. Contributor PRs that need review still require the maintainer to approve before `--auto` takes effect.

## Test plan

This PR is itself being opened with `gh pr merge --auto`, so the workflow is being validated live — if you see it merge on its own within a minute, the setup works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)