### PR TITLE
fix: correct Scope boundaries link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ Make it specific.
 
 ## Scope boundaries
 
-- [ ] I have **not** touched any file listed in [CONTRIBUTING.md § Scope boundaries](../blob/main/CONTRIBUTING.md#scope-boundaries), **or** I have linked the Discussion / Issue that pre-agreed the change below.
+- [ ] I have **not** touched any file listed in [CONTRIBUTING.md § Scope boundaries](../CONTRIBUTING.md#scope-boundaries), **or** I have linked the Discussion / Issue that pre-agreed the change below.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- The Scope-boundaries link in `.github/PULL_REQUEST_TEMPLATE.md` used `../blob/main/CONTRIBUTING.md#scope-boundaries`, which lychee interpreted as a relative filesystem path. Every PR's Link check has been failing with "Cannot find file" on just this one link (111/112 passing).
- Dropped the `blob/main/` segment so the reference resolves both for lychee (as a relative file path from `.github/`) and for GitHub's rendered PR UI (as a CONTRIBUTING.md anchor).

## Test plan
- [x] Local edit verified
- [ ] Link check workflow passes on this PR (observe in Checks tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)