### PR TITLE
fix(docs): repair broken link to deleted example-security-auditor.md

### DIFF
--- a/META_ARCHITECTURE.md
+++ b/META_ARCHITECTURE.md
@@ -92,7 +92,7 @@ flowchart LR
 
 **Not yet bound to any project:** `data-engineer`, `platform-engineer`, `researcher`. The `researcher` role is intentionally unbound — it's domain-agnostic (`requires_context: false`) and invoked directly for evidence-based investigation on any topic.
 
-**See also:** a `roles/README.md` with the schema and binding quick-reference; a `roles/_template.md` for new roles. A filled-in example lives at [`samples/roles/example-security-auditor.md`](samples/roles/example-security-auditor.md).
+**See also:** a `roles/README.md` with the schema and binding quick-reference; a `roles/_template.md` for new roles. A filled-in example lives at [`samples/roles/security-auditor.md`](samples/roles/security-auditor.md) (one of 17 canonical roles shipped in `samples/roles/`).
 
 ---
 


### PR DESCRIPTION
PR #11 replaced `samples/roles/example-security-auditor.md` with the canonical `security-auditor.md` but missed a link in META_ARCHITECTURE.md §2. The `link-check` workflow caught it on PR #11 itself, failing the CI run (and spawning a failure email).

Fix: point the link at `security-auditor.md` + mention the broader 17-role library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)