### PR TITLE
ci(link-check): diff-only on PRs, full-repo on weekly cron

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,11 +1,19 @@
 name: Link check
 
+# Two modes:
+#   - On pull_request: check only the .md files the PR actually changed.
+#     Rationale: whole-repo checks on every PR punish contributors for link rot
+#     they didn't introduce. Diff-only scopes failure to the author's diff.
+#   - On schedule / workflow_dispatch: full-repo sweep. Catches background link
+#     rot (stale vendor URLs, deleted files linked from elsewhere). Auto-opens
+#     an Issue on failure so the maintainer triages on a weekly rhythm.
+
 on:
   pull_request:
     paths:
       - '**/*.md'
   schedule:
-    - cron: '0 6 * * 1'  # Monday 06:00 UTC
+    - cron: '0 6 * * 1' # Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -17,9 +25,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so we can diff the PR head against base.
+          fetch-depth: 0
 
-      - name: Run lychee
-        id: lychee
+      - name: Get changed markdown files (PR only)
+        id: changed
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR \
+            "origin/${{ github.base_ref }}" HEAD -- '*.md' | tr '\n' ' ')
+          if [ -z "$files" ]; then
+            echo "No .md files added/modified in this PR — lychee will be skipped."
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed .md files: $files"
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+            echo "files=$files" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run lychee (PR — diff only)
+        id: lychee_pr
+        if: github.event_name == 'pull_request' && steps.changed.outputs.any_changed == 'true'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --max-concurrency 4
+            ${{ steps.changed.outputs.files }}
+          fail: true
+
+      - name: Run lychee (scheduled / manual — full repo)
+        id: lychee_full
+        if: github.event_name != 'pull_request'
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -27,7 +67,7 @@ jobs:
             --no-progress
             --max-concurrency 4
             './**/*.md'
-          fail: ${{ github.event_name == 'pull_request' }}
+          fail: false
 
       - name: Open issue on scheduled failure
         if: github.event_name == 'schedule' && env.lychee_exit_code != '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 - Diátaxis framing paragraph in `README.md` mapping the repo's docs across tutorial / how-to / reference / explanation quadrants.
 
 ### Changed
+- **`link-check` workflow split into two modes** — on pull requests, lychee now checks only the `.md` files actually changed in the diff (via `git diff --name-only --diff-filter=ACMR`); on the weekly cron and manual dispatch it still runs against the full repo and auto-opens an Issue on failure. Rationale: whole-repo checks on every PR made contributors responsible for link rot they hadn't introduced, and flooded the maintainer's inbox with failure emails on unrelated PRs. Diff-only scopes PR failure to the author's actual change; the weekly cron catches background rot (stale vendor URLs, dangling internal links after deletions) on a reviewable rhythm. Pattern is standard in larger OSS repos (kubernetes, rust, etc.). No third-party action added for the diff — plain `git diff` in a bash step. (2026-04-21)
 - GitHub Actions version bumps via Dependabot: `actions/checkout` 4→6, `actions/setup-python` 5→6, `actions/stale` 9→10, `peter-evans/create-issue-from-file` 5→6, `dessant/lock-threads` 5→6. All pure Node 16→20 runtime upgrades; input APIs unchanged for our usage. (2026-04-20, PRs #1-5)
 
 ---


### PR DESCRIPTION
## Why

Whole-repo link checks on every PR attributed unrelated link rot to whoever submitted next. Contributors got "your PR failed" emails for links in files they never touched; the maintainer got a failure email on every contributor's PR. For a multi-contributor repo that wants to be welcoming, this is bad social UX.

## What changed

- **On `pull_request`:** lychee now checks only the `.md` files actually modified in the PR (`git diff --name-only --diff-filter=ACMR origin/<base_ref> HEAD`). Failure is scoped to the author's own diff.
- **On `schedule` (Mon 06:00 UTC) + `workflow_dispatch`:** full-repo sweep. Auto-opens an Issue on failure so the maintainer triages background rot (stale vendor URLs, dangling internal links after deletions) on a weekly rhythm.

## Trade-off

Diff-only misses a specific case: a PR that *deletes* a file which is linked *from elsewhere* (e.g. [PR #11](https://github.com/jimy-r/claude-workspace-architecture/pull/11) deleted `samples/roles/example-security-auditor.md`, leaving a dangling link in `META_ARCHITECTURE.md` that only appeared on the next PR's check). The weekly cron now catches this kind of rot within 7 days and opens a tracking Issue.

Pattern is standard in larger OSS repos (kubernetes, rust).

## Test plan

- [x] YAML syntax valid (manual review)
- [x] Plain `git diff` in bash step — no third-party action added for the diff
- [x] CHANGELOG.md updated under `[Unreleased] ### Changed`
- [ ] First PR to land after this merges exercises the diff-only path
- [ ] Next Monday's cron exercises the full-repo + auto-Issue path

🤖 Generated with [Claude Code](https://claude.com/claude-code)