### PR TITLE
chore: add secrets and env patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,22 @@
+# Secrets and env (defense-in-depth — the repo has none of these, keep it that way)
+.env*
+credentials*
+secrets*
+*.key
+*.pem
+
+# OS / temp
 .DS_Store
 Thumbs.db
 *.bak
 *.tmp
 *.swp
+
+# Python
 *.pyc
+__pycache__/
+.ruff_cache/
+
+# IDE
 .vscode/
 .idea/
-.ruff_cache/
-__pycache__/


### PR DESCRIPTION
## Summary

- Adds `.env*`, `credentials*`, `secrets*`, `*.key`, `*.pem` to `.gitignore` as a defense-in-depth measure
- Organises existing entries under `OS / temp`, `Python`, `IDE` section headers

## Why

Flagged in the weekly workspace audit (2026-04-21) — the repo has no such files today, and this keeps it that way if one ever slips in via a fork or working tree. Standard hygiene for a public repo.

## Test plan

- [x] `git diff .gitignore` reviewed — additions only, no PII
- [x] Redaction grep clean (no identifiers, paths, or credentials introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)