### PR TITLE
docs: remove shipped subagent skills from planned upgrades

### DIFF
--- a/META_ARCHITECTURE.md
+++ b/META_ARCHITECTURE.md
@@ -440,7 +440,6 @@ Drawn from the live task list and implementation-plan file as of 2026-04-19. Ite
 - **Bittorrent integration** — scope TBD (media server stack / public-domain ebook fetcher / general download manager)
 - **Home integration** — scope TBD (Home Assistant or direct smart-home device integration; potential tie-in with health data — sleep-room temp, morning light)
 - **Job scanner** — scope TBD (career scanner across major boards, grants/RFP scanner, or similar)
-- **Subagent-driven-development + dispatching-parallel-agents skills** — install from an open-source "superpowers" skill pack to codify a subagent-first philosophy
 - **`PreCompact` hook** — add to selected project settings to prevent loss of in-flight state during long tasks
 - **1-hour prompt-cache TTL env var** — set in launcher scripts for 1-hour cache TTL vs default 5-min (materially cuts token spend)
 


### PR DESCRIPTION
## Summary

- Removes one stale bullet from `META_ARCHITECTURE.md` §14 Planned future upgrades.
- The `subagent-driven-development` and `dispatching-parallel-agents` skills shipped on 2026-04-24 (PR #27) and now appear as canonical entries in §5.
- Section's own rule ("Items already shipped are not listed") makes this a housekeeping sync.

## Test plan

- [x] Redaction grep clean (no private identifiers added)
- [x] Diff is a single-line removal — no other content changed
- [x] Section §5 still references both shipped skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
