### PR TITLE
chore: fix auto-cleanup workflow and bump action versions

### DIFF
--- a/.github/workflows/auto-cleanup.yml
+++ b/.github/workflows/auto-cleanup.yml
@@ -13,9 +13,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Prettier on Markdown and YAML
         run: |
-          prettier --write \
+          prettier --write --no-error-on-unmatched-pattern \
             "**/*.md" \
             "**/*.yml" \
             "**/*.yaml" \
@@ -32,7 +32,7 @@ jobs:
             "!.git/**"
 
       - name: Create pull request if changes
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'chore: weekly auto-cleanup (prettier)'
           title: 'chore: weekly auto-cleanup'


### PR DESCRIPTION
## Summary

The weekly `auto-cleanup` workflow has been failing every Monday since 2026-04-27 (5+ consecutive runs). Root cause: `prettier@3` errors on the `**/*.yaml` glob because no `.yaml` files exist in this repo (only `.yml`).

Bundling the fix with the three open dependabot PRs since they all touch the same workflow file and would otherwise force sequential rebases.

## Changes

- Add `--no-error-on-unmatched-pattern` to prettier (keeps the `.yaml` glob in place for future-proofing without breaking the workflow today)
- Bump `actions/checkout` v4 → v6
- Bump `actions/setup-node` v4 → v6
- Bump `peter-evans/create-pull-request` v7 → v8

The version bumps also resolve the Node 20 deprecation warning — v4 actions will be forced off the runner June 2026; v6 actions run on Node 24.

## Supersedes

- Closes #29 — `actions/checkout` v4→v6
- Closes #30 — `peter-evans/create-pull-request` v7→v8
- Closes #31 — `actions/setup-node` v4→v6

## Verification

- [ ] Merge this PR
- [ ] Manually trigger `workflow_dispatch` on the auto-cleanup workflow
- [ ] Confirm it completes green (and either produces no prettier diff or opens a `chore/weekly-auto-cleanup` PR with the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)