### PR TITLE
chore: exclude .github/workflows from prettier in auto-cleanup

### DIFF
--- a/.github/workflows/auto-cleanup.yml
+++ b/.github/workflows/auto-cleanup.yml
@@ -29,7 +29,8 @@ jobs:
             "**/*.yml" \
             "**/*.yaml" \
             "!node_modules/**" \
-            "!.git/**"
+            "!.git/**" \
+            "!.github/workflows/**"
 
       - name: Create pull request if changes
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Summary

Follow-up to #36. The verification run after #36 merged surfaced a second failure: prettier was reformatting `.github/workflows/auto-cleanup.yml` (cosmetic — likely trailing newline or quoting), but the workflow's default \`GITHUB_TOKEN\` doesn't carry \`workflows: write\` permission, so peter-evans/create-pull-request fails to push the branch:

\`\`\`
refusing to allow a GitHub App to create or update workflow .github/workflows/auto-cleanup.yml without \`workflows\` permission
\`\`\`

The cleanup workflow's job is to format the \`samples/\` exemplars, not its own action definition. Excluding \`.github/workflows/**\` from the glob is the safer fix — no elevated permissions needed.

## Verification

- [ ] Merge
- [ ] Trigger \`workflow_dispatch\` again
- [ ] Expect either green-no-diff (if everything already prettified) or green-with-cleanup-PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)