### PR TITLE
chore: audience-reframe — agent workspace, instantiated in Claude Code

### DIFF
--- a/ADOPTION.md
+++ b/ADOPTION.md
@@ -1,6 +1,6 @@
 # Adopting this pattern
 
-A 5-step walkthrough for setting up a similar Claude Code workspace. Each step is independent — you don't have to do all of them, and the order below is just the path of least resistance.
+A 5-step walkthrough for setting up a similar **agent workspace**, instantiated in Claude Code. Each step is independent — you don't have to do all of them, and the order below is just the path of least resistance. The Claude-Code-specific file conventions (`CLAUDE.md`, `.claude/skills/`, MCP config) are the substrate; if you're on a different agent runtime, the architectural decisions still translate even though the file shapes won't.
 
 The full architecture is described in [META_ARCHITECTURE.md](META_ARCHITECTURE.md); this file is the "where to actually start" complement.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,7 +12,7 @@ Where to go for what:
 | Have a **Claude API / SDK question** | [Claude Code documentation](https://docs.claude.com/en/docs/claude-code/overview) |
 | Want to **report a community-health concern** | [Moderation report issue](https://github.com/jimy-r/agent-workspace-architecture/issues/new?template=moderation_report.yml) |
 
-**This repo's scope:** patterns and architectural reference for Claude Code workspaces. It is not the place to debug Claude Code itself, request product features, or ask general usage questions unrelated to workspace architecture.
+**This repo's scope:** patterns and architectural reference for **agent workspaces** (the worked example runs on Claude Code, but the patterns generalise). It is not the place to debug Claude Code itself, request product features, or ask general usage questions unrelated to workspace architecture.
 
 If your question is outside scope, one of the links above will point you at the right place.
 

--- a/samples/.claude/agents/audit-second-opinion.md
+++ b/samples/.claude/agents/audit-second-opinion.md
@@ -15,7 +15,7 @@ tools:
 
 # Second-opinion auditor
 
-You are running as the **second-opinion auditor** for this Claude Code workspace. You exist for one reason: the primary audit agent (`<workspace>/.claude/agents/audit.md`) checks what its own prompt encodes, and an audit can only catch what its prompt thinks to look for. Your job is to catch the things the primary's checklist doesn't.
+You are running as the **second-opinion auditor** for this agent workspace (instantiated in Claude Code). You exist for one reason: the primary audit agent (`<workspace>/.claude/agents/audit.md`) checks what its own prompt encodes, and an audit can only catch what its prompt thinks to look for. Your job is to catch the things the primary's checklist doesn't.
 
 This is the **two-auditor pattern** from financial auditing. Vanta and Drata both require periodic independent third-party assessments for exactly this reason. The primary auditor and you read the same workspace; you should reach somewhat different conclusions.
 


### PR DESCRIPTION
Follow-up sweep after the rename. Three files still positioned the repo as 'Claude Code workspace' (Claude-Code-audience-only) rather than 'agent workspace, instantiated in Claude Code' (substrate-honest + audience-wide).

Plus GitHub About description updated via `gh repo edit` to match the new positioning. Topic `agent-workspace` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)