### PR TITLE
fix(link-check): replace stale Backstage URL + ignore bot-protected domains

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,15 @@
+# Patterns lychee should not check.
+#
+# One regex per line. Use this for URLs that lychee misclassifies as broken,
+# not for URLs that are actually broken — fix the URL in that case.
+#
+# Most common reason to add a pattern here: a domain blocks bots / unauthenticated
+# requests with 403 even though the page resolves fine in a browser. Lychee has no
+# way to distinguish "this URL is dead" from "this server doesn't like bots."
+
+# ACM Digital Library — returns 403 to unauthenticated traffic; DOIs resolve fine
+# interactively. Verify by clicking the link.
+^https://dl\.acm\.org/
+
+# Drata corporate site — bot protection returns 403; URLs resolve fine in a browser.
+^https://drata\.com/

--- a/META_ARCHITECTURE.md
+++ b/META_ARCHITECTURE.md
@@ -484,7 +484,7 @@ This workspace's tooling is not invented from scratch; most load-bearing pattern
 **Audit system** (full bibliography: [`ATTRIBUTION.md` § Audit-system patterns](ATTRIBUTION.md))
 
 - *Continual holistic fitness function* pattern — Ford, Parsons, Kua, Sadalage, *Building Evolutionary Architectures* (O'Reilly, 2nd ed. 2023). The weekly multi-phase audit fits this taxonomy. ArchUnit / NetArchTest / jQAssistant are concrete code-level implementations of the same idea.
-- *Scorecard per catalog entry* — [Backstage Soundcheck](https://backstage.spotify.com/docs/plugins/soundcheck/core-concepts/tech-health) (Spotify). Phase 2 per-project checks.
+- *Scorecard per catalog entry* — [Backstage Soundcheck](https://backstage.spotify.com/plugins/soundcheck/) (Spotify). Phase 2 per-project checks.
 - *Drift detection* — Terraform plan, [driftctl](https://github.com/snyk/driftctl), AWS Config Rules. Phase 2.5a bloat checks.
 - *Tiered automated-vs-human evidence collection* — [Vanta](https://www.vanta.com/products/soc-2), [Drata](https://drata.com/compliance) SOC2-automation platforms. Tier 1/2/3 auto-apply mirrors their automated-vs-human-review distinction.
 - *Atomic security checks* — [OpenSSF Scorecard](https://scorecard.dev/). Phase 2.6 security. Deliberately NO numeric score emitted (Goodhart entry below).


### PR DESCRIPTION
## Summary

Three URLs in §14 Source attribution were tripping the lychee link-check on every PR that touched META_ARCHITECTURE.md:

| URL | Status | Fix |
|---|---|---|
| \`https://backstage.spotify.com/docs/plugins/soundcheck/core-concepts/tech-health\` | 404 | Replaced with canonical landing page \`https://backstage.spotify.com/plugins/soundcheck/\` (verified 200) |
| \`https://dl.acm.org/doi/10.1145/3723158\` | 403 | Added to \`.lycheeignore\` — anti-bot block; URL works in a browser |
| \`https://drata.com/compliance\` | 403 | Added to \`.lycheeignore\` — anti-bot block; URL works in a browser |

## Why

PR #42 (merged earlier today) didn't introduce these — they were pre-existing — but it triggered the workflow because lychee checks the whole file of any touched .md. Without this fix, every future PR that edits META_ARCH.md emails the maintainer a false-positive failure.

The \`.lycheeignore\` convention is standard lychee practice for known anti-bot domains; the file includes inline comments explaining why each pattern is there so future maintainers don't blindly add entries to silence real failures.

## Test plan

- [x] \`curl -I\` confirms the new Backstage URL returns 200.
- [x] \`.lycheeignore\` regex syntax is valid (one pattern per line, lychee's documented format).
- [ ] After merge, the next PR touching META_ARCH should pass link-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)