### PR TITLE
docs: correct branch-protection status now that it is enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Three surfaces to engage: [Discussions](https://github.com/jimy-r/agent-workspac
 
 ## Working principles
 
-- **Always branch** — never commit to `main` directly, even though branch protection isn't enforced.
+- **Always branch** — never commit to `main` directly. Branch protection blocks force-pushes and deletions and requires the `redaction` check to pass on PRs (admins can still self-merge).
 - **One focused change per PR.**
 - **[Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`.
 - **Include `Co-Authored-By:` trailer** for Claude-assisted commits.
@@ -47,9 +47,9 @@ Some files need Discussion/Issue agreement before a PR — see the Scope boundar
 2. `git diff` — eyeball every changed line.
 3. Conventional commit message.
 4. Push your branch; open a PR using the template.
-5. Merge immediately on open:
+5. Merge once the `redaction` check passes:
    `gh pr merge --squash --delete-branch`.
-   The repo has no branch protection on `main` and no required status checks, so `--auto` is rejected by GitHub (it only applies when a PR is blocked on something). Plain merge is instant. Contributor PRs follow the same command once the maintainer has reviewed and approved them.
+   `main` is protected — the `redaction` check must go green before a PR merges, and force-pushes and deletions are blocked. Add `--auto` to queue the merge for when the check passes (if auto-merge is enabled). Contributor PRs follow the same command once the maintainer has reviewed and approved them.
 6. Open the merged commit on GitHub and verify Mermaid / markdown rendered correctly. Any leak or render bug after merge means a follow-up commit — amending never fully erases a public mistake.
 
 ## Tone

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ When in doubt, generalise. Reviewers will bounce PRs that contain identifiers �
 ## Pull-request standards
 
 - **One focused change per PR.** Refactors and content additions go in separate PRs.
-- **Run the redaction check before pushing.** A quick `grep` for personal identifiers, paths, business specifics. Any hit, fix it before `git add`.
+- **Run the redaction check before pushing.** A quick `grep` for personal identifiers, paths, business specifics. Any hit, fix it before `git add`. CI runs an automated pattern-based redaction scan on every PR as a backstop; it catches generic shapes only, so the human grep is still the real check.
 - **Preview rendering on GitHub** if you've touched a Mermaid diagram or heavy markdown — Mermaid especially can render differently between editors and GitHub.
 - **PR description should answer:** what changed, why, and did you run the redaction check?
 - Keep existing tone: terse, structural, opinionated.
@@ -120,7 +120,7 @@ Include a `Co-Authored-By:` trailer for Claude-assisted commits.
 
 ## Branching
 
-- Main branch is `main`. Fork → branch → PR. **Never commit directly to `main`** — the convention matters even though branch protection isn't enforced.
+- Main branch is `main`. Fork → branch → PR. **Never commit directly to `main`** — branch protection blocks force-pushes and deletions and requires the `redaction` check on PRs; direct commits aren't blocked for admins, so the convention still matters.
 - Branch names: short, descriptive — `add-role-X`, `fix-mermaid-section-9`, `improve-heartbeat-loop`.
 - Delete merged branches; the repo has auto-delete enabled.
 


### PR DESCRIPTION
Follow-up to the redaction-gate PR (#45). Branch protection is now active on the default branch (force updates + deletions blocked, `redaction` check required on PRs), so three doc lines that said it "isn't enforced" are now stale, and the old "merge immediately / `--auto` is rejected" guidance no longer holds.

- **CLAUDE.md** — working principle + "Before you push" step 5 corrected.
- **CONTRIBUTING.md** — Branching note corrected; PR-standards bullet now notes the CI redaction scan as a backstop to the manual grep.

Docs-only. The `redaction` check runs on this PR too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
