### PR TITLE
docs: add ninth pattern — context is a budget, not a constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Human-written record of notable changes — the *why* and the *shape*, not every merged PR. The repo doesn't cut releases; entries are grouped by date, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), adapted to a dated scheme.
 
+## 2026-06-11
+
+- **Ninth pattern: "Context is a budget, not a constant."** The Token Budget module arrived as a module row in the 2026-06-10 sync; this gives the thinking its `PATTERNS.md` entry (problem → pattern → why → cost, pointing at `ghost_token_counter.py` + `token_report.py` samples), adds the ninth card to the tour, and retires the "eight" count from the README, the tour button and heading, and the social-card description.
+
 ## 2026-06-10
 
 - **Workspace-upgrade sync.** The source workspace's latest batch, mirrored in: a twelfth module — **Token Budget** (a deterministic preflight gate that skips no-op scheduled cycles, a model-tier policy for unattended work, daily spend telemetry feeding the audit's trend rule) — plus audit hardening: a coded assertion runner (`samples/scripts/audit_checks/run_all.py` — LLM re-derivation of checks had produced a false positive), canary verification rewritten to assert *detection* end-of-run rather than fixture presence, a provenance gate so externally-sourced findings never auto-apply, a ledger emit-count assertion, the full report relocated out of the task list, and a new `audit-workthrough` skill that drains pending findings. New samples: `preflight_gate.py`, `token_report.py`, the checks runner, and the workthrough skill; the scheduler-wrapper sample gained the gate + a per-skill model map; the tour gained the twelfth module; the samples README inventory corrected (it had drifted well behind the tree). Also fixes the one lychee failure from the consistency pass (a sample-settings link path).

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -100,12 +100,24 @@ Read this when you want the *why*. [META_ARCHITECTURE.md](META_ARCHITECTURE.md) 
 
 **Where it lives:** [`samples/.claude/agents/audit.md`](samples/.claude/agents/audit.md) and [`samples/tests/audit_canaries/`](samples/tests/audit_canaries/).
 
+## 9. Context is a budget, not a constant
+
+**Problem.** Everything auto-loaded into a session — instruction files, the memory index, skill descriptions, hook strings — costs tokens on every turn, in every session. No single addition is large, so the total grows a few percent a week, and unattended agents spend with nobody watching. Quality erodes before any cost alarm fires.
+
+**Pattern.** Meter it like money. A baseline counter measures every always-loaded source individually and keeps history. A trend alarm fires when the baseline beats its rolling median by a set margin, because accretion is the common failure, not the blowout. Unattended runs carry hard spend ceilings sized as belts (10–50x a normal cycle), multi-agent fan-outs are bounded by construction, index files carry explicit size ceilings, and a standing note tells the runtime what must survive context compaction.
+
+**Why this beats the obvious.** The obvious control is a size warning on the main instruction file: one source, one absolute threshold. The real failure is distributed (a dozen sources each growing slightly) and relative (this month versus last), so per-source measurement with trend detection catches what a static ceiling misses. Attribution is the payoff: a total says something grew; the breakdown says what to trim.
+
+**Cost.** A counter and its history to maintain, estimates that drift from true tokenizer counts, and ceilings that need sizing judgment — a cap set as a governor instead of a belt aborts legitimately heavy runs.
+
+**Where it lives:** [`samples/scripts/ghost_token_counter.py`](samples/scripts/ghost_token_counter.py) (the per-source baseline) and [`samples/scripts/token_report.py`](samples/scripts/token_report.py) (spend telemetry feeding the audit's trend rule).
+
 ## How they compose
 
-These are not independent. The credential law and the file-protection hook are the same instinct (keep damage out of durable surfaces) applied at two layers. The roles library and memory hygiene are the same instinct (one source of truth, referenced rather than copied) applied in two domains. Classify-then-act and tier-by-impact are the same instinct (route by consequence, not by confidence) applied to tasks and to findings.
+These are not independent. The credential law and the file-protection hook are the same instinct (keep damage out of durable surfaces) applied at two layers. The roles library and memory hygiene are the same instinct (one source of truth, referenced rather than copied) applied in two domains. Classify-then-act and tier-by-impact are the same instinct (route by consequence, not by confidence) applied to tasks and to findings. And the context budget is the audit's instinct (notice drift before it bites) pointed at the one resource every other pattern spends.
 
 Adopt them when you feel the friction each one removes. Not before.
 
 ---
 
-*Last verified against the repo structure on 2026-06-10.*
+*Last verified against the repo structure on 2026-06-11.*

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The example runs in [Claude Code](https://claude.com/claude-code), so the file c
 
 This is one person's actual setup, redacted and published as a reference. Not a framework, not a product. A documented working arrangement of the pieces Claude Code already gives you, with the reasoning attached.
 
-**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — a five-minute visual pass: the layered architecture, the eight load-bearing patterns, and one task moving through the system end to end.
+**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — a five-minute visual pass: the layered architecture, the nine load-bearing patterns, and one task moving through the system end to end.
 
-[![The interactive tour: layered architecture, eight patterns, a task end to end](docs/assets/tour-hero.png)](https://jimy-r.github.io/agent-workspace-architecture/)
+[![The interactive tour: layered architecture, nine patterns, a task end to end](docs/assets/tour-hero.png)](https://jimy-r.github.io/agent-workspace-architecture/)
 
 ## What's inside
 
@@ -24,7 +24,7 @@ Tables throughout mark each component `[stock]` / `[plugin]` / `[local]` / `[cus
 
 ## Start with the why
 
-If you read one thing past this page, read **[PATTERNS.md](PATTERNS.md)** — the eight load-bearing architectural decisions, each as *problem → pattern → why it beats the obvious alternative → what it costs*. That's where the actual thinking lives.
+If you read one thing past this page, read **[PATTERNS.md](PATTERNS.md)** — the nine load-bearing architectural decisions, each as *problem → pattern → why it beats the obvious alternative → what it costs*. That's where the actual thinking lives.
 
 The rest of the docs follow [Diátaxis](https://diataxis.fr/):
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Agent Workspace Architecture — an interactive tour">
-<meta name="twitter:description" content="A worked reference for a personal agent workspace, with the reasoning attached: eight load-bearing patterns and one task moving through the system end to end.">
+<meta name="twitter:description" content="A worked reference for a personal agent workspace, with the reasoning attached: nine load-bearing patterns and one task moving through the system end to end.">
 <meta name="twitter:image" content="https://jimy-r.github.io/agent-workspace-architecture/assets/social-card.png">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%237F1D1D'/%3E%3Ctext x='32' y='45' font-family='Georgia,serif' font-size='38' font-weight='bold' text-anchor='middle' fill='%23FBF9F4'%3EA%3C/text%3E%3C/svg%3E">
 <!-- Static, dependency-free, GitHub-Pages-ready. The markdown docs remain source of truth; this is a view over them. -->
@@ -165,7 +165,7 @@
     <p class="meta">One person's actual setup, redacted and published with the reasoning attached. The example runs in Claude Code, but the architecture ports to any agent runtime. This page is the five-minute tour; the docs hold the depth.</p>
     <div class="btns">
       <a href="#architecture" class="btn primary">Explore the architecture</a>
-      <a href="#patterns" class="btn ghost">Read the 8 patterns</a>
+      <a href="#patterns" class="btn ghost">Read the 9 patterns</a>
     </div>
     <div class="pillrow" aria-hidden="true">
       <span class="pill">17 expert roles</span>
@@ -224,7 +224,7 @@
 <section id="patterns">
   <div class="wrap">
     <p class="eyebrow">The thinking</p>
-    <h2>Eight load-bearing patterns</h2>
+    <h2>Nine load-bearing patterns</h2>
     <p class="lede">If you read one thing, read these — each as problem, pattern, why it beats the obvious alternative, and what it costs. Expand any card.</p>
     <div class="patterns" id="patterns-grid"></div>
     <div class="compose">
@@ -320,7 +320,8 @@
     {n:"05", title:"Memory points, it doesn't mirror", problem:"Agent memory that copies your source documents goes stale the moment a source changes, then quietly contradicts it.", pattern:"Memory holds an index plus typed notes that point at the source of truth instead of duplicating it. Every write is one of four operations — add, update, delete, no-op — never a blind append.", why:"Dumping everything into memory feels safe and rots fast. A pointer cannot contradict its source; a copy eventually always does.", cost:"Discipline at write time, plus a periodic consolidation pass to merge duplicates and prune the index."},
     {n:"06", title:"Credentials live in one place, never in files", problem:"A secret written to a file leaks: into git history, into a backup, into an agent's context window, into a screenshot.", pattern:"A password manager is the single store. Files reference the item name, never the value. Running code resolves the secret at runtime and scrubs it. Allow one narrow, audited exception per genuine need, not a general waiver.", why:"A .env file and “I'll just paste it for now” are how secrets end up in transcripts forever. One store with runtime resolution keeps the value off every durable surface.", cost:"A runtime lookup step, and the discipline to refuse the convenient shortcut."},
     {n:"07", title:"A cheap hook beats a careful agent", problem:"An agent that misread the task can overwrite a secrets file, delete a record, or force-push. “Be more careful” does not scale.", pattern:"A PreToolUse hook intercepts file writes and shell commands against a blocklist — sensitive paths, destructive verbs, pushes to protected branches — and blocks them before they run. It fails open, so a bug in the guard never wedges the session.", why:"Trusting the model to never err is a hope, not a control. A ten-line deterministic check catches the large majority of accidental damage for almost nothing.", cost:"Occasional false positives, best resolved by naming around them rather than widening the gap."},
-    {n:"08", title:"Audit the workspace like a fitness function", problem:"A workspace degrades. Context bloats, configs drift, a hook stops firing, memory contradicts reality, and nobody's job is to notice.", pattern:"A scheduled auditor sweeps configs, the security envelope, and drift on a cadence, writing tiered findings. Canaries verify it still detects known-bad fixtures. Deliberately no single numeric score — a self-grading audit optimises for the grade.", why:"“I'll clean it up when it bothers me” loses to a cadence with canaries, because drift is gradual and invisible right up until it isn't.", cost:"The audit is itself a system to maintain, and it can cry wolf, so findings are tiered and tracked rather than dumped raw."}
+    {n:"08", title:"Audit the workspace like a fitness function", problem:"A workspace degrades. Context bloats, configs drift, a hook stops firing, memory contradicts reality, and nobody's job is to notice.", pattern:"A scheduled auditor sweeps configs, the security envelope, and drift on a cadence, writing tiered findings. Canaries verify it still detects known-bad fixtures. Deliberately no single numeric score — a self-grading audit optimises for the grade.", why:"“I'll clean it up when it bothers me” loses to a cadence with canaries, because drift is gradual and invisible right up until it isn't.", cost:"The audit is itself a system to maintain, and it can cry wolf, so findings are tiered and tracked rather than dumped raw."},
+    {n:"09", title:"Context is a budget, not a constant", problem:"Everything auto-loaded into a session — instruction files, the memory index, skill descriptions, hook strings — costs tokens on every turn, forever. No single addition is large, so the total grows a few percent a week, and unattended agents spend with nobody watching.", pattern:"Meter it like money. A per-source baseline counter with history, a trend alarm against a rolling median (accretion is the common failure, not the blowout), hard spend ceilings on unattended runs, fan-outs bounded by construction, and a standing note on what must survive compaction.", why:"A size warning on one instruction file watches one source and one absolute threshold. The real failure is distributed and relative, so per-source measurement with trend detection catches what a static ceiling misses.", cost:"A counter to maintain, estimates that drift from true tokenizer counts, and ceilings that need sizing judgment — a cap set as a governor instead of a belt aborts legitimately heavy runs."}
   ];
 
   var steps = [


### PR DESCRIPTION
Completes the Token Budget story: the module row landed in the 2026-06-10 sync (#55); this adds the thinking as PATTERNS.md #9 (problem → pattern → why → cost, pointing at the ghost_token_counter.py and token_report.py samples), the ninth tour card, a compose-section line, and retires the eight count from README (intro + image alt + start-with-the-why), the tour button/heading, and the social-card description. CHANGELOG entry included. Tour re-verified locally via headless render: nine cards inject, heading updated, stepper intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)