### PR TITLE
docs(tour): add UTM tags to the tour's jamesross.ai links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,7 @@
       <a href="#in-motion" class="hideable">In motion</a>
       <a href="#build" class="hideable">Build it</a>
       <a href="https://github.com/jimy-r/agent-workspace-architecture">GitHub</a>
-      <a href="https://jamesross.ai" class="cta">jamesross.ai</a>
+      <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=nav&amp;utm_campaign=flagship" class="cta">jamesross.ai</a>
     </span>
   </div>
 </nav>
@@ -369,7 +369,7 @@
 
     <div class="funnel">
       <h3>Standing this up inside an organisation?</h3>
-      <p>I'm James Ross. I design agent workspaces and AI-orchestration systems, and this is the reference version of my own. If you want these patterns adapted to your stack, the practice site is <a href="https://jamesross.ai">jamesross.ai</a>.</p>
+      <p>I'm James Ross. I design agent workspaces and AI-orchestration systems, and this is the reference version of my own. If you want these patterns adapted to your stack, the practice site is <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=funnel&amp;utm_campaign=flagship">jamesross.ai</a>.</p>
     </div>
   </div>
 </section>
@@ -378,7 +378,7 @@
   <div class="wrap">
     <span>MIT licensed · a curated solo reference, maintained best-effort.</span>
     <a href="https://github.com/jimy-r/agent-workspace-architecture">Repository</a>
-    <a href="https://jamesross.ai">jamesross.ai</a>
+    <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=footer&amp;utm_campaign=flagship">jamesross.ai</a>
   </div>
 </footer>
 


### PR DESCRIPTION
## What this does

Completes the UTM attribution started in #70 (which covered the README). The tour page's three jamesross.ai links now carry `utm_source=tour` with a distinct `utm_medium` each, so you can see which placement on the tour drives clicks to the practice site:

- nav CTA → `utm_medium=nav`
- funnel block → `utm_medium=funnel`
- footer → `utm_medium=footer`

`utm_campaign=flagship` throughout. HTML-valid `&amp;` entities in the hrefs; link text and CTA framing unchanged.

Together with #70's `utm_source=github` (README), you now get attribution split by surface (README vs tour) and, on the tour, by placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
