### PR TITLE
docs(site): link signal-sweep as the spun-out standalone tool

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -370,6 +370,8 @@
       <a class="doc" href="https://github.com/jimy-r/agent-workspace-architecture/tree/main/samples"><span class="dt">samples/ → Scaffold</span><span class="dd">Role, skill, and context files to fork and adapt.</span></a>
     </div>
 
+    <p style="font-size:14.5px; color:var(--muted); margin:18px 0 0;"><strong style="color:var(--ink);">Spun out as a standalone tool:</strong> <a href="https://github.com/signal-sweep/signal-sweep">signal-sweep</a> generalizes this workspace's thread-sweep module into a human-gated toolkit for finding the open GitHub threads your project's docs already answer.</p>
+
     <div class="agentbox">
       <span class="k">Hand the repo to your own agent</span>
       <code>Tour this repo. Read PATTERNS.md, then META_ARCHITECTURE.md, then WORKFLOW.md, then scan samples/. Summarise the patterns most applicable to my workspace.</code>


### PR DESCRIPTION
Adds a one-line related-project pointer to the tour's Go-deeper section, linking signal-sweep (the human-gated presence toolkit generalized from this workspace's thread-sweep module). Matches the palette (muted text, no new CSS), no private data. Lets signal-sweep inherit the flagship's discovery surface. Left for your review + merge since it touches the live tour page.