### PR TITLE
docs: byline + funnel copy catch up with the Agent-Ready Knowledge Architecture practice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Human-written record of notable changes — the *why* and the *shape*, not every merged PR. Milestone batches get a tagged release with short notes (from `v1.0.0`, 2026-06-11); entries are grouped by date, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), adapted to a dated scheme.
 
+## 2026-07-13
+
+- **The author byline caught up with the practice.** README "Who built this", the tour's funnel card, and SUPPORT's engagement row now carry the current positioning (AI Knowledge Architect; the practice is Agent-Ready Knowledge Architecture) and frame the repo as the reference version of the practice's agent-ready memory layer. Same batch: `llms.txt` now lists the tour itself plus CHANGELOG and WORKFLOW as sources, and this changelog was backfilled for the merges since v1.5.0 that had gone unrecorded.
+
 ## 2026-07-12
 
 - **signal-sweep cross-linked from the README and the tour.** The sibling repo (a narrower, single-purpose extraction of the thread-sweep pattern) had no path back to the broader architecture it came from; the README's repo list and the tour's closing section now both point at it.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The repo's [`CLAUDE.md`](CLAUDE.md) auto-loads on session start, so your agent i
 
 ## Who built this
 
-James Ross. I design agent workspaces and AI-orchestration systems, and this is the reference version of my own. If you're standing up something similar inside an organisation, or want these patterns adapted to your stack, the practice site is **[jamesross.ai](https://jamesross.ai/?utm_source=github&utm_medium=readme&utm_campaign=flagship)**.
+James Ross. I work as an AI Knowledge Architect; the practice is **Agent-Ready Knowledge Architecture** — making an organisation's knowledge legible to AI agents. This workspace is the reference version of my own agent-ready memory layer: the source-of-truth conventions, context architecture, and memory governance the practice teaches, running daily in production. If you're standing up something similar inside an organisation, or want these patterns adapted to your stack, the practice site is **[jamesross.ai](https://jamesross.ai/?utm_source=github&utm_medium=readme&utm_campaign=flagship)**.
 
 ## Using it
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ Where to go for what:
 | **Built something** in your own workspace and want to share it | [Discussions](https://github.com/jimy-r/agent-workspace-architecture/discussions) |
 | Found a **Claude Code bug** (CLI, app, hooks, subagents, skills) | [anthropics/claude-code issues](https://github.com/anthropics/claude-code/issues), not here |
 | Have a **Claude API / SDK question** | [Claude Code documentation](https://docs.claude.com/en/docs/claude-code/overview) |
-| Want to engage the author for **agent-workspace or AI-orchestration work** | [jamesross.ai](https://jamesross.ai) |
+| Want to engage the author for **Agent-Ready Knowledge Architecture work** (agent-ready memory, context architecture, agent workspaces) | [jamesross.ai](https://jamesross.ai) |
 
 **This repo's scope:** a curated architectural reference for **agent workspaces** (the worked example runs on Claude Code; the patterns generalise). It's a solo-maintained showcase, not a support desk, so it isn't the place to debug Claude Code itself, request product features, or get general usage help. The links above point you at the right place for each.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -379,7 +379,7 @@
 
     <div class="funnel">
       <h3>Standing this up inside an organisation?</h3>
-      <p>I'm James Ross. I design agent workspaces and AI-orchestration systems, and this is the reference version of my own. If you want these patterns adapted to your stack, the practice site is <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=funnel&amp;utm_campaign=flagship">jamesross.ai</a>.</p>
+      <p>I'm James Ross, an AI Knowledge Architect. The practice is Agent-Ready Knowledge Architecture: making an organisation's knowledge legible to AI agents. This workspace is the reference version of my own agent-ready memory layer. If you want these patterns adapted to your stack, the practice site is <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=funnel&amp;utm_campaign=flagship">jamesross.ai</a>.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What

Relabels the three author/funnel touchpoints to the current positioning (AI Knowledge Architect; the practice is **Agent-Ready Knowledge Architecture**) and frames the repo as the reference version of the practice's agent-ready memory layer:

- `README.md` § Who built this
- `docs/index.html` funnel card (tour)
- `SUPPORT.md` engagement row
- `CHANGELOG.md` — dated entry for this batch

## Why

The practice repositioned; the repo's byline still described the pre-pivot framing. The funnel copy and the destination site should tell one story (the site's own relabel deploys separately).

Redaction gate: clean (run locally pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)