### PR TITLE
fix: broken mermaid diagram in META_ARCHITECTURE §3, plus a CI check so it can't recur

### DIFF
--- a/.github/workflows/mermaid-check.yml
+++ b/.github/workflows/mermaid-check.yml
@@ -1,0 +1,47 @@
+name: Mermaid check
+
+# GitHub renders Mermaid client-side, so a diagram with a syntax error ships
+# without ever failing at commit time — readers just get a red "Unable to render
+# rich display" box. STYLE_GUIDE tells authors to verify rendering on GitHub
+# after a diagram change; that rule is self-attested and was skipped at least
+# once, putting a reserved-word node id (`call`) into META_ARCHITECTURE §3.
+# This job is the deterministic check behind the rule.
+#
+# docs/llms-full.txt isn't scanned: it is generated from the markdown sources
+# and gated by llms-full-check, so clean sources make it clean.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'scripts/check_mermaid.mjs'
+      - '.github/workflows/mermaid-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/check_mermaid.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # Pinned rather than floating: an upstream Mermaid release should not turn
+      # an unrelated contributor's PR red. Bump deliberately, and re-run the
+      # whole repo when you do — GitHub tracks its own Mermaid version, so the
+      # pin is an approximation of the renderer, not a guarantee.
+      - name: Install Mermaid parser
+        run: npm install --no-save mermaid@11.17.0 jsdom@27.0.0
+
+      - name: Parse every mermaid block
+        run: node scripts/check_mermaid.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ Thumbs.db
 *.tmp
 *.swp
 
+# Node (scripts/check_mermaid.mjs installs mermaid + jsdom with --no-save)
+node_modules/
+package-lock.json
+
 # Python
 *.pyc
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ When in doubt, generalise. Reviewers will bounce PRs that contain identifiers, n
 
 - **One focused change per PR.** Refactors and content additions go in separate PRs.
 - **Run the redaction check before pushing.** A quick `grep` for personal identifiers, paths, business specifics. Any hit, fix it before `git add`. CI runs an automated pattern-based redaction scan on every PR as a backstop; it catches generic shapes only, so the human grep is still the real check.
-- **Preview rendering on GitHub** if you've touched a Mermaid diagram or heavy markdown. Mermaid especially can render differently between editors and GitHub.
+- **Run the Mermaid check if you've touched a diagram:** `npm install --no-save mermaid jsdom && node scripts/check_mermaid.mjs`. CI runs it too. Then still preview on GitHub, because parsing clean and laying out well are different things.
 - **PR description should answer:** what changed, why, and did you run the redaction check?
 - Keep existing tone: terse, structural, opinionated.
 

--- a/META_ARCHITECTURE.md
+++ b/META_ARCHITECTURE.md
@@ -144,10 +144,10 @@ flowchart LR
     role["Canonical role<br/>roles/security-auditor.md<br/>(pure, no entity facts)"]
     ctx["Project CONTEXT.md<br/>(entity facts: stack, paths, decisions)"]
     binding["Thin binding<br/>project/.claude/agents/<br/>project-security.md<br/>(role + CONTEXT via @ includes)"]
-    call["@project-security<br/>invocable subagent"]
+    invoke["@project-security<br/>invocable subagent"]
     role --> binding
     ctx --> binding
-    binding --> call
+    binding --> invoke
 ```
 
 **Validation:** a roles validator script checks frontmatter schema + binding composition. It ran every heartbeat cycle until that agent was retired in 2026-08; it now runs inside the `health` composite and on demand, and a non-zero exit surfaces to the operator in session rather than into a questions tracker.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -44,7 +44,8 @@ Markers help readers budget adoption effort at a glance.
 - **Use Mermaid** (GitHub renders it natively). Don't commit ASCII diagrams except inside `<details>` as text fallback.
 - Flowcharts for hierarchy, sequence diagrams for workflows, state diagrams where relevant.
 - Keep node text short; use `<br/>` for line breaks inside a node label.
-- After committing a diagram change, open the file on GitHub and verify rendering. Mermaid renders slightly differently in different editors.
+- **Validate before you push:** `npm install --no-save mermaid jsdom && node scripts/check_mermaid.mjs` parses every diagram in the repo. CI runs the same check, so a syntax error fails the PR instead of shipping as a red "Unable to render rich display" box.
+- Parsing is not rendering. After a diagram change, still open the file on GitHub and look at it. Mermaid lays out slightly differently in different editors.
 
 ## Freshness footer
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -470,10 +470,10 @@ flowchart LR
     role["Canonical role<br/>roles/security-auditor.md<br/>(pure, no entity facts)"]
     ctx["Project CONTEXT.md<br/>(entity facts: stack, paths, decisions)"]
     binding["Thin binding<br/>project/.claude/agents/<br/>project-security.md<br/>(role + CONTEXT via @ includes)"]
-    call["@project-security<br/>invocable subagent"]
+    invoke["@project-security<br/>invocable subagent"]
     role --> binding
     ctx --> binding
-    binding --> call
+    binding --> invoke
 ```
 
 **Validation:** a roles validator script checks frontmatter schema + binding composition. It ran every heartbeat cycle until that agent was retired in 2026-08; it now runs inside the `health` composite and on demand, and a non-zero exit surfaces to the operator in session rather than into a questions tracker.

--- a/scripts/check_mermaid.mjs
+++ b/scripts/check_mermaid.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Validate every ```mermaid fence in the repo's markdown against the real
+ * Mermaid parser.
+ *
+ * Why this exists: GitHub renders Mermaid client-side, so a diagram with a
+ * syntax error doesn't fail loudly at commit time — it ships, and readers get a
+ * red "Unable to render rich display" box where the diagram should be. The
+ * STYLE_GUIDE rule ("open the file on GitHub and verify rendering") is
+ * self-attested and was silently skipped at least once, which is how a
+ * reserved-word node id (`call`, the `click X call fn()` keyword) reached main
+ * in META_ARCHITECTURE §3. This is the check behind that rule.
+ *
+ * Parses with securityLevel 'strict' to match GitHub's own configuration.
+ * docs/llms-full.txt is not scanned directly — it is generated from the five
+ * markdown sources and gated by llms-full-check, so clean sources make it clean.
+ *
+ * Usage:
+ *   node scripts/check_mermaid.mjs            # whole repo
+ *   node scripts/check_mermaid.mjs A.md B.md  # only these files
+ *
+ * Requires: npm install --no-save mermaid jsdom
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SKIP_DIRS = new Set(['.git', 'node_modules', '__pycache__', '.github/ISSUE_TEMPLATE']);
+const FENCE = /^([ \t]*)```mermaid[ \t]*$\n([\s\S]*?)^\1```[ \t]*$/gm;
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+// Mermaid needs a DOM even to parse. jsdom is enough; a headless browser is not
+// required because we never render to SVG.
+const { JSDOM } = await import('jsdom');
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+// navigator is a getter-only property on the Node global; defineProperty is the
+// only way to shim it.
+Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
+for (const k of ['HTMLElement', 'SVGElement', 'Element', 'Node', 'DOMParser']) globalThis[k] = dom.window[k];
+
+const mermaid = (await import('mermaid')).default;
+mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
+
+const files = process.argv.length > 2 ? process.argv.slice(2) : walk('.');
+let blocks = 0;
+const failures = [];
+
+for (const file of files) {
+  if (!fs.existsSync(file)) continue;
+  const src = fs.readFileSync(file, 'utf8');
+  for (const m of src.matchAll(FENCE)) {
+    blocks++;
+    // 1-indexed line of the opening fence, so the error is clickable.
+    const line = src.slice(0, m.index).split('\n').length;
+    try {
+      await mermaid.parse(m[2], { suppressErrors: false });
+    } catch (e) {
+      failures.push({ file, line, message: String(e?.message ?? e).trim() });
+    }
+  }
+}
+
+for (const f of failures) {
+  console.error(`\n${f.file}:${f.line} — mermaid parse error`);
+  console.error(f.message.split('\n').map((l) => '    ' + l).join('\n'));
+}
+
+const scanned = process.argv.length > 2 ? `${files.length} file(s)` : 'the repo';
+if (failures.length) {
+  console.error(`\n${failures.length} of ${blocks} mermaid block(s) failed to parse.`);
+  process.exit(1);
+}
+console.log(`${blocks} mermaid block(s) in ${scanned}: all parse.`);


### PR DESCRIPTION
## What changed

Two things: the broken diagram, and the check that would have caught it.

**1. The bug.** `META_ARCHITECTURE.md` §3 (roles composition) used `call` as a flowchart node id. `call` is a reserved keyword in Mermaid's grammar — it's the `click <node> call <fn>()` interaction syntax — so the lexer emits `CALLBACKNAME` on `binding --> call` and the whole block fails to parse:

```
Parse error on line 8:
...  binding --> call
---------------------^
Expecting 'AMP', 'COLON', 'PIPE', 'TESTSTR', 'DOWN', 'DEFAULT', 'NUM',
'COMMA', 'NODE_STRING', 'BRKT', 'MINUS', 'MULT', 'UNICODE_TEXT',
got 'CALLBACKNAME'
```

GitHub renders Mermaid client-side, so nothing failed at commit time. The diagram just showed up as a red "Unable to render rich display" box for every reader. Reported by a reader, not by any gate here.

Renamed the node to `invoke`. `docs/llms-full.txt` regenerated from the corrected source, so `llms-full-check` stays green.

**2. The check.** `scripts/check_mermaid.mjs` pulls every ` ```mermaid ` fence out of the repo's markdown and parses it with the real Mermaid parser under `securityLevel: 'strict'` (GitHub's own configuration), reporting `file:line` of the opening fence and exiting non-zero on failure. `.github/workflows/mermaid-check.yml` runs it on any PR touching a `.md`.

## Why the check, and not just the fix

`STYLE_GUIDE.md:47` already said "After committing a diagram change, open the file on GitHub and verify rendering." The rule existed. Nothing fires when it's skipped, and skipping it is exactly how this shipped. A self-attested rule on a failure mode this silent wants a deterministic check behind it.

The docs now point at the script (STYLE_GUIDE § Diagrams, CONTRIBUTING § Before you open a PR) while keeping the eyeball step, because parsing clean and laying out well are different claims.

## Verification

- All three diagrams in the repo parse after the fix; blocks 1 and 3 were already clean.
- **Known-positive tested:** reintroducing the `call` node id fails the run at `META_ARCHITECTURE.md:142`, exit 1. Reverting passes, exit 0. The check detects the bug it was built for, rather than merely passing on green input.
- `python scripts/redaction_check.py` → clean.
- `python scripts/gen_llms_full.py --check` → current.
- Validated against mermaid 11.17.0.

## Notes for review

- **The dependency pin is deliberate.** Floating would let an upstream Mermaid release turn an unrelated contributor's PR red. The tradeoff: GitHub tracks its own Mermaid version, so the pin approximates the renderer rather than guaranteeing it. Bump on purpose and re-run the repo when you do.
- **Freshness footers left alone.** They read "Last verified against the repo structure on X", which is a claim about a full-document pass. This PR makes targeted edits and didn't re-verify those documents end to end, so bumping the dates would assert a check that didn't happen. Say the word if you'd rather they move.
- `node_modules/` and `package-lock.json` added to `.gitignore`, since the script installs with `--no-save`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
