### PR TITLE
docs: teardowns section — conventions, ground rules, and page template

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The rest of the docs follow [Diátaxis](https://diataxis.fr/):
 | Quadrant | Doc | Read it for |
 |---|---|---|
 | Explanation | [PATTERNS.md](PATTERNS.md) | why the shape is the way it is |
+| Evidence | [teardowns/](teardowns/) | published architectures read against the patterns |
 | Reference | [META_ARCHITECTURE.md](META_ARCHITECTURE.md) | the full structural map, with diagrams |
 | Tutorial | [ADOPTION.md](ADOPTION.md) | a 5-step build, minimum-viable at each step |
 | Explanation | [EVALUATION.md](EVALUATION.md) | how to tell whether a workspace change actually helped |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -70,6 +70,7 @@ The rest of the docs follow [Diátaxis](https://diataxis.fr/):
 | Quadrant | Doc | Read it for |
 |---|---|---|
 | Explanation | [PATTERNS.md](PATTERNS.md) | why the shape is the way it is |
+| Evidence | [teardowns/](teardowns/) | published architectures read against the patterns |
 | Reference | [META_ARCHITECTURE.md](META_ARCHITECTURE.md) | the full structural map, with diagrams |
 | Tutorial | [ADOPTION.md](ADOPTION.md) | a 5-step build, minimum-viable at each step |
 | Explanation | [EVALUATION.md](EVALUATION.md) | how to tell whether a workspace change actually helped |

--- a/teardowns/README.md
+++ b/teardowns/README.md
@@ -1,0 +1,41 @@
+# Teardowns
+
+Written analyses of published agent architectures: what a design gets right, what it trades off, and what it conspicuously lacks, measured against the [seventeen patterns](../PATTERNS.md) this repository documents.
+
+## Why teardowns
+
+A pattern says what tends to work. A teardown shows the pattern meeting a real, published system built by someone else, and that meeting is where the interesting evidence lives. Which patterns show up independently, which are absent even in strong designs, and where a design makes a trade the patterns don't anticipate. Each page here is one such reading.
+
+Subjects are found by [teardown-sweep](https://github.com/signal-sweep/signal-sweep/tree/main/modules/teardown_sweep), which ranks published architectures by how much a teardown would have to say. A system implementing several patterns while conspicuously lacking others beats one that matches everything or nothing.
+
+## Ground rules
+
+These are conditions for a page existing here, not style preferences.
+
+1. **Published, credited work only.** The subject chose to publish; the teardown links back prominently and names what works before what doesn't.
+2. **The artefact is the subject, never the author.** Critique the design and its trade-offs. No speculation about intent, skill, or effort.
+3. **Proportionality.** A well-resourced published reference invites a different depth of scrutiny than a small personal project by an unknown author. Punch sideways or up.
+4. **Never delivered to the subject's own space.** A teardown is published here and shared on neutral ground. It is never posted into the subject's repo, tracker, or forum. A private heads-up to the author is a courtesy worth considering; it is a judgment call, not a step.
+5. **Verifiable claims.** Every observation cites the file or doc it reads from, at the revision read. If it can't be cited, it isn't claimed.
+
+## Page conventions
+
+One file per teardown: `YYYY-MM-DD-<subject-slug>.md`, opening with a header block:
+
+```markdown
+# Teardown: <subject name>
+
+- **Subject:** <repo or publication URL>
+- **Revision read:** <commit sha or date of the material>
+- **Patterns present:** <numbers, e.g. 1, 7, 9>
+- **Patterns absent worth noting:** <numbers>
+- **Date:** YYYY-MM-DD
+```
+
+Body structure, in order: **What it is** (two or three sentences, neutral) · **What works** (the strongest choices, credited) · **The trade-offs** (what the design pays for those choices) · **What's conspicuously absent** (patterns the design would benefit from, and why their absence shows) · **What this teaches** (what transfers to other workspaces, which is the reason the page exists).
+
+## Distribution
+
+Pages here are the canonical copies. Sharing on aggregator venues (with each venue's own etiquette) is a manual act; teardown-sweep's `suggested_venues` field proposes where each subject's audience already is, and its ledger records where a finished teardown actually ran.
+
+*(No teardowns published yet. The first pages land as subjects clear the ranked queue.)*


### PR DESCRIPTION
A designated home for written teardowns of published agent architectures, read against the seventeen patterns.

- teardowns/README.md: why teardowns, five ground rules (published+credited only; artefact not author; proportionality; never delivered into the subject's own space; verifiable claims), page naming + header template, distribution stance (canonical copies here; venue sharing manual, proposed by teardown-sweep's suggested_venues).
- README table gains an Evidence row; docs/llms-full.txt regenerated (README is a source doc).

Subjects come from signal-sweep's teardown-sweep module; no pages yet — the section ships before the first teardown so the first one has conventions to land into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)