### PR TITLE
teardown: LifeOS + herdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Human-written record of notable changes — the *why* and the *shape*, not every merged PR. Milestone batches get a tagged release with short notes (from `v1.0.0`, 2026-06-11); entries are grouped by date, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), adapted to a dated scheme.
 
+## 2026-08-28
+
+- **Two teardowns: [LifeOS](teardowns/2026-08-28-lifeos.md) and [herdr](teardowns/2026-08-28-herdr.md).** Both came through the engagement lane rather than the ranked queue — each followed a public design exchange in the subject's own discussions. LifeOS (read at `ce046f26495c`): the single-skill distribution discipline and declined-as-a-first-class capability state earn the praise; the absences cluster on measurement, silent-failure detection, context economics and provenance, and the measurement gap played out in public when a "v7 feels worse" thread ran on single-trial evidence. herdr (read at `7b675f42af35`): the pane-state model and agent-native wait-until-blocked coordination are ahead of the field; the runtime that owns every agent's terminal still accounts for none of what those agents cost or did unattended, and its own discussions show that layer being designed in real time. The teardowns index now lists all three published pages.
+
 ## 2026-08-27
 
 - **The interactive tour caught up to the pattern set, and the reader surface stopped disagreeing with itself.** The tour rendered cards for patterns 1–15 while the set stood at 18; patterns 16 (provenance), 17 (one canonical copy) and 18 (position is price) now render as first-class cards, hand-authored from their PATTERNS.md text. Alongside it, the drift-reconcile pass corrected every stale count and claim across the reader surface (README, META, ADOPTION, SUPPORT, WORKFLOW, the tour, and the llms bundles), including a roles count that disagreed between two lines of the same README, and added a docs-consistency CI check so a numeric pattern claim that drifts from PATTERNS.md fails the build instead of waiting for a reader to notice.

--- a/teardowns/2026-08-28-herdr.md
+++ b/teardowns/2026-08-28-herdr.md
@@ -1,0 +1,43 @@
+# Teardown: herdr
+
+- **Subject:** https://github.com/herdrdev/herdr
+- **Revision read:** `7b675f42af35` (2026-08-27); surfaces read: `README.md`, repo structure, plus the public design exchange in [discussion #2746](https://github.com/herdrdev/herdr/discussions/2746)
+- **Patterns present:** 2 (partial), 12, 14 (partial)
+- **Patterns absent worth noting:** 3, 8, 9, 16
+- **Date:** 2026-08-28
+
+## What it is
+
+herdr is "the runtime your coding agents live on", a single Rust binary that runs as a background server and owns the terminals your agents run in. Sessions survive lid-closes, network drops and restarts. Every pane carries a state of working, blocked or idle, and agents drive the runtime themselves through a CLI and socket API, spawning panes, prompting each other, and waiting until another agent is genuinely blocked. At 33k stars it is one of the most-adopted pieces of agent infrastructure going, and it deliberately wraps nothing. Claude Code, Codex, Cursor and the rest run unmodified inside it.
+
+## What works
+
+**The pane state model is the right primitive.** Working, blocked, idle, surfaced per pane, with "never hunt for the stuck one" as the promise (`README.md`). That is the classify-then-act shape (pattern 2) applied to operator attention. The runtime classifies, and the human acts on the one that needs them. Anyone who has run six agents in six terminals knows this is the actual daily problem, and herdr made it the centre of the product rather than a dashboard afterthought.
+
+**Agent-native control is ahead of the field.** The socket API's wait-until-blocked semantics give agents a real coordination primitive. An orchestrating agent can hand work to another pane and block on genuine need rather than polling or guessing (pattern 14's delegation mechanics, provided as infrastructure). Most multi-agent coordination today is prompt-mediated hope. herdr made it a syscall.
+
+**Persistence as a deliberate stance.** Always-running is a considered answer to the loop-selection question (pattern 12), not an accident. The runtime exists precisely so sessions outlive the terminal that started them, reattachable from anywhere including over SSH. One binary, no Electron, is the same discipline applied to the dependency surface.
+
+## The trade-offs
+
+**Owning the terminal buys legibility and pays in responsibility.** Because herdr owns every agent's terminal, it is positioned to see everything: what ran, what it cost, what changed. At this revision it spends that position almost entirely on liveness and attention. That is a defensible sequencing choice for a runtime finding adoption, but it means the layer best placed to account for agent work currently accounts only for whether it is stuck.
+
+**Detach-and-walk-away moves the trust boundary.** The pitch is close the lid and let them keep working. Unattended operation is exactly where the runtime's visibility matters most, and where the absences below stop being theoretical.
+
+## What's conspicuously absent
+
+**Spend visibility (pattern 9), and the project knows it.** Discussion #2746 opens with the failure that makes the case. Eleven fix rounds re-reading 650k tokens, each round individually reasonable, the runaway visible only across the loop. The maintainers engaged seriously in that thread on where a cross-round budget should live, launch-gate floors versus mid-turn kills, ledgers, and alert design. It is a genuinely good design conversation. But at revision `7b675f42af35` the runtime that watches every pane still carries no notion of what a pane costs: no per-run ledger, no budget, no spend trend. The runtime is the only layer that can hold a cross-round number, which is exactly why the absence shows.
+
+**A dead-man's switch over always-running agents (pattern 3).** herdr tells you when an agent is blocked. Nothing tells you when an agent that should have produced something has quietly produced nothing, which is the failure mode that always-running infrastructure inherits the moment users take the detach-and-walk-away promise seriously. Liveness is not freshness.
+
+**An audit trail for unattended work (pattern 16).** After a detached weekend, the questions are what each agent did, what it touched, and on whose instruction. Pane scrollback is not an answer. Scrollback is where provenance goes to die. A runtime that owns the terminal is the natural writer of an append-only record of unattended work, and no such record exists at this revision.
+
+**A fitness function for the fleet (pattern 8).** With states, uptimes and (eventually) costs per pane, the runtime holds everything needed to say this fleet is healthier or sicker than last week. Nothing aggregates it.
+
+## What this teaches
+
+The runtime layer is consolidating faster than the accountability layer. herdr has effectively won the "where do agents live" question for a large slice of the ecosystem, and the things it lacks are not features it rejected but a layer nobody has shipped: budgets, ledgers, freshness sentinels, provenance of unattended work. Discussion #2746 shows that layer being designed in public, in real time, by maintainers who take it seriously. The transferable lesson for any workspace is to put the accounting where the loop lives. Per-turn visibility can never see an eleven-round runaway, and whichever layer owns the loop owns the responsibility for the number.
+
+---
+
+*Found via the engagement lane: the budget-and-ledger design exchange in discussion #2746 preceded this page. Conventions: [teardowns/README.md](README.md). Corrections welcome and will be appended, dated.*

--- a/teardowns/2026-08-28-lifeos.md
+++ b/teardowns/2026-08-28-lifeos.md
@@ -1,0 +1,43 @@
+# Teardown: LifeOS
+
+- **Subject:** https://github.com/danielmiessler/LifeOS
+- **Revision read:** `ce046f26495c` (2026-08-14); surfaces read: `README.md`, `LifeOS/SKILL.md`, `LifeOS/Tools/` and `LifeOS/Workflows/` listings, plus the public evaluation thread in [discussion #1715](https://github.com/danielmiessler/LifeOS/discussions/1715)
+- **Patterns present:** 1, 7, 17 (partial)
+- **Patterns absent worth noting:** 3, 9, 11, 16
+- **Date:** 2026-08-28
+
+## What it is
+
+LifeOS is Daniel Miessler's "Life Operating System", a general-purpose AI harness layer that captures who you are (the TELOS interview), holds your goals as current-state versus ideal-state, and rides on top of whatever coding harness you already run. At 18.7k stars it is one of the most-adopted personal AI operating layers in the ecosystem, and it ships as a single self-contained skill whose agentic installer sets up the whole system.
+
+## What works
+
+**The distribution discipline is genuinely good.** The entire system ships as one `LifeOS/` directory holding the orchestrator, the workflows, the install payload and the bootstrap script (`LifeOS/SKILL.md`, "How it ships"). The skill file is explicit that nothing ships outside it, and it names its single sources of truth for both install paths. It even documents its own versioning trap: the skill's component version and the release version are different numbers, and the file tells the reader never to confuse them. That is one-canonical-copy thinking (pattern 17) applied to distribution, and most projects at this scale don't have it.
+
+**Capability states are honest.** The `doctor` route prints four states for every capability — live, broken, declined, stale — with the exact fix command for anything broken. The instruction that follows is the best line in the file. A declined capability is "a legitimate way to run LifeOS, never a defect to nag about". Respecting *declined* as a first-class state, distinct from *broken*, is a design courtesy most installers never extend.
+
+**Hooks are wired with permission, per step.** The installer (`Tools/InstallHooks.ts`, `Workflows/Setup.md`) asks before it touches anything, and setup always precedes the interview so guardrails exist before personal data flows. The skill/workflow routing table is clean pattern-1 composition: five triggers, five targets, no ambiguity.
+
+## The trade-offs
+
+**Install-by-prompt is the new `curl | bash`.** The primary install is "give this document to your AI and say install this". It is honest about what it is, and permission-gated at each step, but it normalises handing an agent a remote document with instruction-following authority. The community already senses this: in discussion #1715 a user describes their own agent first checking whether `ourlifeos.ai` was a typosquat before agreeing to install. That user improvised, ad hoc, the read-before-install gate the ecosystem hasn't standardised yet. The trade is real reach (any harness, one prompt) against training users to pipe documents into agents, and LifeOS at least makes the trade visibly.
+
+**An always-loaded personal OS is a standing context spend.** LifeOS adds a permanent instruction surface (system prompt, algorithm, skills, hooks) to every session of the harness it rides on. The README's pitch is that full context makes everything better. The bill for full context is paid on every single turn, and nothing in the read surfaces prices it.
+
+## What's conspicuously absent
+
+**Measurement (pattern 11), and this one played out in public.** Discussion #1715 is users reporting that v7 "feels" worse, six byte-identical sessions splitting 4/2 on outcome, and single-trial A/B cells read as verdicts. The maintainer responded, and a community eval with a confidence box followed, which is more than most projects manage. But the system itself ships no golden set, no pass-rate-with-variance harness, no gate that a scaffolding change must beat a baseline before adoption. For a project whose whole premise is that its scaffolding raises your effectiveness, the absence of an instrument that could demonstrate it is the gap that hurts most. The thread shows the culture arriving; the repo at this revision doesn't yet carry the tooling.
+
+**Silent failure detection (pattern 3).** `doctor` is a pull diagnostic. Excellent when a human thinks to run it, silent otherwise. A hook that dies, a stale capability, a broken integration all wait for someone to ask. Nothing fires on its own when a piece of an always-running life system quietly stops.
+
+**Context economics (pattern 9).** No budget, no per-session cost visibility, no notion that the always-loaded surface competes with the work. Related closely to the trade-off above.
+
+**Provenance (pattern 16).** The system holds durable personal state (TELOS, memory, dashboards) and nothing in the read surfaces requires a claim drawn from that state to carry its source. For a system whose product is statements about your own life, "where did this come from" deserves first-class treatment.
+
+## What this teaches
+
+Three things transfer. Distribution as a single self-contained artifact with named sources of truth is worth stealing at any scale. Treating declined as a first-class state deserves adoption across the whole capability-gating world, because an operator who said no is not a bug. And the eval story is the clearest public demonstration yet that measurement culture reaches personal-AI systems through community pressure before it reaches them through design; a project that shipped its golden set first would have answered #1715 with a number instead of a thread.
+
+---
+
+*Found via the engagement lane rather than the ranked queue: the evaluation-methodology exchange in discussion #1715 preceded this page. Conventions: [teardowns/README.md](README.md). Corrections welcome and will be appended, dated.*

--- a/teardowns/README.md
+++ b/teardowns/README.md
@@ -38,4 +38,10 @@ Body structure, in order: **What it is** (two or three sentences, neutral) · **
 
 Pages here are the canonical copies. Sharing on aggregator venues (with each venue's own etiquette) is a manual act; teardown-sweep's `suggested_venues` field proposes where each subject's audience already is, and its ledger records where a finished teardown actually ran.
 
-*(No teardowns published yet. The first pages land as subjects clear the ranked queue.)*
+## Published
+
+| Date | Subject | Revision read |
+|---|---|---|
+| 2026-08-28 | [herdr](2026-08-28-herdr.md) | `7b675f42af35` |
+| 2026-08-28 | [LifeOS](2026-08-28-lifeos.md) | `ce046f26495c` |
+| 2026-08-27 | [12-Factor Agents](2026-08-27-12-factor-agents.md) | `d20c728` |


### PR DESCRIPTION
Two engagement-lane teardowns per teardowns/README.md conventions, both version-pinned with claims cited to read surfaces:

- **LifeOS** at `ce046f26495c` — praised: single-skill distribution discipline, declined-as-first-class capability states, permission-gated hook install. Absent: measurement (played out publicly in discussion #1715), silent-failure detection, context economics, provenance.
- **herdr** at `7b675f42af35` — praised: pane-state model, agent-native wait-until-blocked coordination, persistence-as-stance. Absent: spend visibility (their own discussion #2746 is the evidence), dead-man's switch, unattended-work audit trail, fleet fitness function.

Plus: teardowns/README index of the three published pages (replacing the stale none-yet line) and the CHANGELOG entry. Style gate run on both pages; redaction clean.

Launch authorized by the founder's overnight goal; author notifications deliberately NOT sent — staged privately per ground rule 4 for wake review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)