### PR TITLE
style: tour to the charcoal-amber palette; lead with the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Human-written record of notable changes — the *why* and the *shape*, not every
 
 ## 2026-08-29
 
+- **The reader surface moved to the charcoal-amber palette, and the map became the front door.** The tour and the map page now share one look — charcoal ink on cream with bronze and amber accents, the same palette the map wears on the author's practice site — replacing the oxblood scheme, favicon included. Prominence followed the palette: the README leads with the map before the tour, and the tour hero carries a "See it on one page" button. Still red until regenerated: the README's static tour screenshot and the social card.
+
 - **The whole architecture on one page: [The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html).** The tour takes five minutes and META_ARCHITECTURE takes an hour; nothing served the thirty-second read. The new page draws the running system as five bands — entry points feeding the session (rules, typed memory, and lessons loaded at start; skills, seventeen roles, and workflows invoked from it), the governance floor under every action, persistent state on one side and human-gated outputs on the other, with the watcher rail (weekly audit, dead-man's switch, security digest, token meter, verified backups) spanning the lot. The claim the page exists to make: the complexity is quantity, not structure. Every box names a real component documented elsewhere in the repo. Linked from the tour nav, the sitemap, and llms.txt.
 
 ## 2026-08-28

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A reference implementation of **agent-ready knowledge architecture**: the roles,
 
 [![The interactive tour's opening view: the workspace thesis, the 18 patterns, and the working chips — click through for the live tour](docs/assets/tour-static.png)](https://jimy-r.github.io/agent-workspace-architecture/)
 
-**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — the clickable five-minute version: the layered architecture, the eighteen load-bearing patterns, and one task moving through the system end to end.
+**▣ [The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html)** — start here: the entire architecture in one diagram, a thirty-second read. Entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.
 
-Prefer one picture? **[The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html)** collapses the entire architecture onto a single page — entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.
+**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — the clickable five-minute version: the layered architecture, the eighteen load-bearing patterns, and one task moving through the system end to end.
 
 Feeding this to a model instead? [`llms.txt`](https://jimy-r.github.io/agent-workspace-architecture/llms.txt) is the link map, and [`llms-full.txt`](https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt) inlines the whole reference in a single fetch.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
 <meta name="twitter:title" content="Agent Workspace Architecture — an interactive tour">
 <meta name="twitter:description" content="A worked reference for a personal agent workspace, with the reasoning attached: eighteen load-bearing patterns and one task moving through the system end to end.">
 <meta name="twitter:image" content="https://jimy-r.github.io/agent-workspace-architecture/assets/social-card.png">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%237F1D1D'/%3E%3Ctext x='32' y='45' font-family='Georgia,serif' font-size='38' font-weight='bold' text-anchor='middle' fill='%23FBF9F4'%3EA%3C/text%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231B1A17'/%3E%3Ctext x='32' y='45' font-family='Georgia,serif' font-size='38' font-weight='bold' text-anchor='middle' fill='%23E2A83E'%3EA%3C/text%3E%3C/svg%3E">
 <!-- Plain-text views of the same reference, for models that read llms.txt. -->
 <link rel="alternate" type="text/plain" href="llms.txt" title="llms.txt — link map of the reference">
 <link rel="alternate" type="text/plain" href="llms-full.txt" title="llms-full.txt — the whole reference inlined">
@@ -45,8 +45,8 @@
 <!-- Static, dependency-free, GitHub-Pages-ready. The markdown docs remain source of truth; this is a view over them. -->
 <style>
   :root{
-    --ink:#1B1A17; --oxblood:#7F1D1D; --oxblood-soft:#9b3b3b;
-    --paper:#FBF9F4; --card:#FFFFFF; --muted:#6B6964; --rule:#E7E3DA;
+    --ink:#1B1A17; --oxblood:#8F6414; --oxblood-soft:#A9821E;
+    --paper:#FBFAF7; --card:#FFFFFF; --muted:#5B574F; --rule:#E6E1D8;
     --shadow:0 1px 2px rgba(27,26,23,.05),0 8px 24px rgba(27,26,23,.06);
     --maxw:1080px;
   }
@@ -69,7 +69,7 @@
   .lede{font-size:18px; color:var(--muted); max-width:62ch; margin:0 0 26px;}
 
   /* nav */
-  nav.top{position:sticky; top:0; z-index:30; background:rgba(251,249,244,.9); backdrop-filter:saturate(140%) blur(8px); border-bottom:1px solid var(--rule);}
+  nav.top{position:sticky; top:0; z-index:30; background:rgba(251,250,247,.9); backdrop-filter:saturate(140%) blur(8px); border-bottom:1px solid var(--rule);}
   nav.top .wrap{display:flex; align-items:center; gap:18px; height:56px;}
   nav.top .brand{font-family:Georgia,serif; font-weight:700; font-size:16px; color:var(--ink); white-space:nowrap;}
   nav.top .links{display:flex; gap:16px; margin-left:auto; align-items:center; flex-wrap:wrap;}
@@ -88,7 +88,7 @@
   .btn.primary{background:var(--oxblood); color:#fff;}
   .btn.primary:hover{background:var(--oxblood-soft); text-decoration:none;}
   .btn.ghost{background:transparent; color:var(--oxblood);}
-  .btn.ghost:hover{background:rgba(127,29,29,.06); text-decoration:none;}
+  .btn.ghost:hover{background:rgba(143,100,20,.06); text-decoration:none;}
   .pillrow{display:flex; gap:8px; flex-wrap:wrap; margin-top:30px;}
   .pill{font-size:12.5px; color:var(--muted); border:1px solid var(--rule); background:var(--card); border-radius:999px; padding:5px 11px;}
 
@@ -128,9 +128,9 @@
   details.pat .body .row{margin-top:12px;}
   details.pat .body .k{font-size:11.5px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; color:var(--oxblood);}
   details.pat .body .v{font-size:15px; margin-top:2px;}
-  .compose{margin-top:20px; background:#2a1414; color:#f3e9e4; border-radius:12px; padding:22px 24px;}
+  .compose{margin-top:20px; background:#201C15; color:#F5EEDC; border-radius:12px; padding:22px 24px;}
   .compose h3{color:#fff; margin:0 0 8px; font-size:20px;}
-  .compose p{margin:0; color:#e8d7d0; font-size:15.5px; max-width:74ch;}
+  .compose p{margin:0; color:#DDD3BC; font-size:15.5px; max-width:74ch;}
 
   /* stepper */
   .pipe{display:flex; flex-wrap:wrap; gap:6px; margin:6px 0 22px;}
@@ -154,10 +154,10 @@
   .doc:hover{border-color:var(--oxblood-soft); text-decoration:none; box-shadow:var(--shadow);}
   .doc .dt{display:block; font-family:Georgia,serif; font-weight:700; font-size:16px; color:var(--ink);}
   .doc .dd{display:block; font-size:14px; color:var(--muted); margin-top:3px;}
-  .agentbox{margin-top:22px; background:var(--card); border:1px dashed #cdbfae; border-radius:11px; padding:18px 20px;}
+  .agentbox{margin-top:22px; background:var(--card); border:1px dashed #CDBF9E; border-radius:11px; padding:18px 20px;}
   .agentbox .k{font-size:11.5px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; color:var(--oxblood);}
   .agentbox code{display:block; margin-top:8px; font-family:"SFMono-Regular",Consolas,"Liberation Mono",monospace; font-size:13.5px; color:var(--ink); background:var(--paper); border:1px solid var(--rule); border-radius:7px; padding:12px 14px; white-space:pre-wrap; line-height:1.5;}
-  .funnel{margin-top:24px; padding:22px 24px; border-radius:12px; background:linear-gradient(180deg,#fff, #f6efe6); border:1px solid var(--rule);}
+  .funnel{margin-top:24px; padding:22px 24px; border-radius:12px; background:linear-gradient(180deg,#fff, #F5EEDC); border:1px solid var(--rule);}
   .funnel h3{margin:0 0 6px; font-size:21px;}
   .funnel p{margin:0; color:var(--muted); font-size:16px; max-width:64ch;}
   footer{padding:34px 0 56px; color:var(--muted); font-size:13.5px;}
@@ -191,6 +191,7 @@
     <div class="btns">
       <a href="#architecture" class="btn primary">Explore the architecture</a>
       <a href="#patterns" class="btn ghost">Read the 18 patterns</a>
+      <a href="workspace-map.html" class="btn ghost">See it on one page &rarr;</a>
     </div>
     <div class="pillrow" aria-hidden="true">
       <span class="pill">17 expert roles</span>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -38,9 +38,9 @@ A reference implementation of **agent-ready knowledge architecture**: the roles,
 
 [![The interactive tour's opening view: the workspace thesis, the 18 patterns, and the working chips — click through for the live tour](docs/assets/tour-static.png)](https://jimy-r.github.io/agent-workspace-architecture/)
 
-**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — the clickable five-minute version: the layered architecture, the eighteen load-bearing patterns, and one task moving through the system end to end.
+**▣ [The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html)** — start here: the entire architecture in one diagram, a thirty-second read. Entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.
 
-Prefer one picture? **[The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html)** collapses the entire architecture onto a single page — entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.
+**▶ [Take the interactive tour](https://jimy-r.github.io/agent-workspace-architecture/)** — the clickable five-minute version: the layered architecture, the eighteen load-bearing patterns, and one task moving through the system end to end.
 
 Feeding this to a model instead? [`llms.txt`](https://jimy-r.github.io/agent-workspace-architecture/llms.txt) is the link map, and [`llms-full.txt`](https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt) inlines the whole reference in a single fetch.
 

--- a/docs/workspace-map.html
+++ b/docs/workspace-map.html
@@ -6,6 +6,7 @@
 <title>The workspace, mapped — Agent Workspace Architecture</title>
 <meta name="description" content="The entire agent workspace architecture on one page: entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.">
 <link rel="canonical" href="https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231B1A17'/%3E%3Ctext x='32' y='45' font-family='Georgia,serif' font-size='38' font-weight='bold' text-anchor='middle' fill='%23E2A83E'%3EA%3C/text%3E%3C/svg%3E">
 <style>
   :root {
     --ink: #1B1A17;


### PR DESCRIPTION
The repo's reader surface joins the map on the charcoal-amber palette, and the map becomes the front door.

- **Tour restyle** — token-value swap: oxblood → bronze (#8F6414) with amber accents on cream; the dark compose panel and tinted cards re-tinted to match; favicon now a charcoal square with an amber A. Render-verified locally: 18 pattern cards render, JS intact, three hero buttons.
- **Map prominence** — README leads with **The workspace, mapped** ahead of the tour; the tour hero gains a "See it on one page →" button; the map page gets the matching favicon.
- llms-full.txt regenerated for the README change; CHANGELOG entry added.
- Known follow-up: `assets/tour-static.png` (README hero image) and `assets/social-card.png` still show the old red palette until regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)