### PR TITLE
docs: add guided learn track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Human-written record of notable changes — the *why* and the *shape*, not every merged PR. Milestone batches get a tagged release with short notes (from `v1.0.0`, 2026-06-11); entries are grouped by date, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), adapted to a dated scheme.
 
+## 2026-08-30
+
+- **A guided learn track: seven modules over the eighteen patterns.** [`learn/`](learn/README.md) opens on a foundations module that runs the session loop once, then walks six maturity dimensions: canonical knowledge, context economics, verification and oversight, safety and permissions, telemetry and cost, and provenance and delegation. Each module explains why the capability matters, points at the patterns that build it, and ends on an exercise with a mechanical done-check rather than a reflect-on prompt. A hands-on companion tutorial ships in the starter repo: seven steps that stand up a working scaffold instead of reading about one.
+
 ## 2026-08-29
 
 - **The reader surface moved to the charcoal-amber palette, and the map became the front door.** The tour and the map page now share one look — charcoal ink on cream with bronze and amber accents, the same palette the map wears on the author's practice site — replacing the oxblood scheme, favicon included. Prominence followed the palette: the README now opens with the map itself rendered inline as the hero image (the diagram extracted to a standalone SVG plus a 2x PNG in assets), and the tour hero carries a "See it on one page" button. Still red until regenerated: the README's static tour screenshot and the social card.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The rest of the docs follow [Diátaxis](https://diataxis.fr/):
 | Evidence | [teardowns/](teardowns/) | published architectures read against the patterns |
 | Reference | [META_ARCHITECTURE.md](META_ARCHITECTURE.md) | the full structural map, with diagrams |
 | Tutorial | [ADOPTION.md](ADOPTION.md) | a 5-step build, minimum-viable at each step |
+| Tutorial | [learn/](learn/) | a guided track through the patterns, by capability, with exercises |
 | Explanation | [EVALUATION.md](EVALUATION.md) | how to tell whether a workspace change actually helped |
 | How-to | [samples/](samples/) | scaffold files to fork and adapt |
 | How-to | [tools/workspace_check.py](tools/workspace_check.py) | run a scored check of your own workspace |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -79,6 +79,7 @@ The rest of the docs follow [Diátaxis](https://diataxis.fr/):
 | Evidence | [teardowns/](teardowns/) | published architectures read against the patterns |
 | Reference | [META_ARCHITECTURE.md](META_ARCHITECTURE.md) | the full structural map, with diagrams |
 | Tutorial | [ADOPTION.md](ADOPTION.md) | a 5-step build, minimum-viable at each step |
+| Tutorial | [learn/](learn/) | a guided track through the patterns, by capability, with exercises |
 | Explanation | [EVALUATION.md](EVALUATION.md) | how to tell whether a workspace change actually helped |
 | How-to | [samples/](samples/) | scaffold files to fork and adapt |
 | How-to | [tools/workspace_check.py](tools/workspace_check.py) | run a scored check of your own workspace |

--- a/learn/00-foundations.md
+++ b/learn/00-foundations.md
@@ -1,0 +1,26 @@
+# M0. Foundations — the session loop
+
+> [Learn track](README.md) · start here, or wherever the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) says you're weakest.
+
+A governed agent workspace is an ordinary folder with three properties: the agent starts every session knowing where things stand, nothing important happens outside a recorded plan, and every correction you make becomes a rule the next session reads. None of that requires a framework. It requires files, a few skills, and the discipline to use them.
+
+The unit of work is the **session loop**:
+
+1. **Orient.** The agent reads a small fixed file set — active plan, task list, lessons, open questions — and briefs you: state, in-flight work, one recommended next action. Fixed set, because "look around and get up to speed" burns context on speculative reading and comes back with a different picture every time.
+2. **Plan.** Work gets a checklist in a todo file before implementation starts. You approve the plan, not the diff.
+3. **Work.** The agent executes, marking items as they complete.
+4. **Wrap.** Completed work is integrated everywhere it belongs — task list updated, lessons captured, registries swept — instead of left in the diff for future archaeology.
+
+The loop is small enough to feel bureaucratic on day one. It stops feeling that way the first time a session picks up exactly where the last one stopped, or the first time the agent declines to repeat a mistake because the correction was written down.
+
+## Do this
+
+Run the loop once end to end. Either in your own workspace (any folder with a `CLAUDE.md` and a task file will do) or by scaffolding the [starter template](https://github.com/jimy-r/agent-workspace-starter?utm_source=github&utm_medium=repo&utm_campaign=learn-track), which ships orient, tasks, and wrap as working skills.
+
+**Done-check:** your task file shows one item added and struck through, and the session ended with a wrap that updated it — not with a summary in chat that no file records.
+
+## Measure it
+
+Take the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and keep the six-dimension result. It's the baseline the rest of the track moves.
+
+Next: [M1. Canonical knowledge](01-canonical-knowledge.md), or jump to your weakest dimension.

--- a/learn/00-foundations.md
+++ b/learn/00-foundations.md
@@ -1,6 +1,6 @@
 # M0. Foundations — the session loop
 
-> [Learn track](README.md) · start here, or wherever the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) says you're weakest.
+> [Learn track](README.md) · start here, or wherever the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track) says you're weakest.
 
 A governed agent workspace is an ordinary folder with three properties: the agent starts every session knowing where things stand, nothing important happens outside a recorded plan, and every correction you make becomes a rule the next session reads. None of that requires a framework. It requires files, a few skills, and the discipline to use them.
 
@@ -21,6 +21,6 @@ Run the loop once end to end. Either in your own workspace (any folder with a `C
 
 ## Measure it
 
-Take the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and keep the six-dimension result. It's the baseline the rest of the track moves.
+Take the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and keep the six-dimension result. It's the baseline the rest of the track moves.
 
 Next: [M1. Canonical knowledge](01-canonical-knowledge.md), or jump to your weakest dimension.

--- a/learn/01-canonical-knowledge.md
+++ b/learn/01-canonical-knowledge.md
@@ -1,6 +1,6 @@
 # M1. Canonical knowledge — one source of truth
 
-> [Learn track](README.md) · dimension: **Canonical knowledge** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Canonical knowledge** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 The failure this module prevents is quiet: the same rule written in three files, all correct on the day they were written, one edited later. An agent loading all three now reads two versions and silently picks one. Nothing breaks. You just get a wrong answer months later with no obvious cause.
 

--- a/learn/01-canonical-knowledge.md
+++ b/learn/01-canonical-knowledge.md
@@ -1,0 +1,25 @@
+# M1. Canonical knowledge — one source of truth
+
+> [Learn track](README.md) · dimension: **Canonical knowledge** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+The failure this module prevents is quiet: the same rule written in three files, all correct on the day they were written, one edited later. An agent loading all three now reads two versions and silently picks one. Nothing breaks. You just get a wrong answer months later with no obvious cause.
+
+The fix is structural, not disciplinary. Every fact gets exactly one canonical home; everything else points at it and says it's a pointer. A pointer can go stale, but stale-and-broken is loud. A copy that drifts is quiet, and quiet is the enemy.
+
+## The patterns
+
+- [**Pattern 1. Pure roles, composed with project facts**](../PATTERNS.md#1-pure-roles-composed-with-project-facts) — expert personas hold method with zero entity facts; project specifics live in a `CONTEXT.md`; a thin binding composes the two. A fix to the role reaches every project at once.
+- [**Pattern 5. Memory points, it doesn't mirror**](../PATTERNS.md#5-memory-points-it-doesnt-mirror) — agent memory holds an index and typed notes that point at sources of truth. A pointer cannot contradict its source; a copy eventually always does.
+- [**Pattern 17. One canonical copy, and pointers from everywhere else**](../PATTERNS.md#17-one-canonical-copy-and-pointers-from-everywhere-else) — the same instinct applied to instruction files, where duplication costs tokens on every session *and* drifts.
+
+## Do this
+
+Find one rule that exists in two of your instruction files (a communication preference, a git convention, a formatting rule — grep a distinctive phrase from your main instruction file across the rest). Pick the canonical home. Reduce the other instance to a one-line pointer naming the file and section — a reference, not a summary, because a summary is a copy that drifts more slowly.
+
+**Done-check:** the phrase now greps to exactly one file plus pointers, and the pointer names its target explicitly.
+
+## Measure it
+
+[`claudemd_audit.py`](../samples/scripts/claudemd_audit.py) inventories every always-loaded instruction file and flags cross-file duplicated boilerplate. Run it before and after; the duplication count should drop by at least one.
+
+Next: [M2. Context economics](02-context-economics.md) — what the duplicated copy was costing you per session.

--- a/learn/02-context-economics.md
+++ b/learn/02-context-economics.md
@@ -1,6 +1,6 @@
 # M2. Context economics — context is spend
 
-> [Learn track](README.md) · dimension: **Memory & context economics** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Memory & context economics** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 Two facts most workspaces learn late. First, everything auto-loaded into a session — instructions, memory index, skill descriptions — costs tokens on every turn of every session, and it grows a few percent a week because no single addition is large. Second, the model API is stateless: the whole transcript is re-sent on every tool call, so a token's real cost is its size times the number of steps that follow it. A large file read at turn 3 is re-paid hundreds of times; the same read at turn 180, a handful. Size is what everyone watches. Position and step-count are what multiply it.
 
@@ -19,6 +19,6 @@ Two moves, same session. (1) Measure your always-loaded surface — every file t
 
 ## Measure it
 
-[`ghost_token_counter.py`](../samples/scripts/ghost_token_counter.py) is the per-source baseline with history; [`token_report.py`](../samples/scripts/token_report.py) reads real spend per session. The [context carry-cost calculator](https://jamesross.ai/tools/context-cost.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) prices a read by position if you want the intuition before the instrument.
+[`ghost_token_counter.py`](../samples/scripts/ghost_token_counter.py) is the per-source baseline with history; [`token_report.py`](../samples/scripts/token_report.py) reads real spend per session. The [context carry-cost calculator](https://jamesross.ai/tools/context-cost?utm_source=github&utm_medium=repo&utm_campaign=learn-track) prices a read by position if you want the intuition before the instrument.
 
 Next: [M3. Verification & oversight](03-verification-oversight.md).

--- a/learn/02-context-economics.md
+++ b/learn/02-context-economics.md
@@ -1,0 +1,24 @@
+# M2. Context economics — context is spend
+
+> [Learn track](README.md) · dimension: **Memory & context economics** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+Two facts most workspaces learn late. First, everything auto-loaded into a session — instructions, memory index, skill descriptions — costs tokens on every turn of every session, and it grows a few percent a week because no single addition is large. Second, the model API is stateless: the whole transcript is re-sent on every tool call, so a token's real cost is its size times the number of steps that follow it. A large file read at turn 3 is re-paid hundreds of times; the same read at turn 180, a handful. Size is what everyone watches. Position and step-count are what multiply it.
+
+Neither fact argues for reading less. Reading less makes the agent dumber, which is the one saving never worth making. The levers move *where* and *when* the same information is paid for.
+
+## The patterns
+
+- [**Pattern 9. Context is a budget, not a constant**](../PATTERNS.md#9-context-is-a-budget-not-a-constant) — meter the always-loaded surface per source with history, alarm on trend, cap unattended runs with belts sized 10–50x normal.
+- [**Pattern 18. Position is price**](../PATTERNS.md#18-position-is-price--a-token-costs-more-the-earlier-you-add-it) — bulk reading goes to a subagent whose transcript is separate; ranged reads beat whole-file reads; defer big reads to the step that needs them; batch independent tool calls into one step.
+
+## Do this
+
+Two moves, same session. (1) Measure your always-loaded surface — every file the agent reads at session start — and write the per-file token estimate down. (2) Take the largest habitual early read in your sessions and move it: to a subagent that returns a summary, to a ranged read, or later in the session.
+
+**Done-check:** you can name your three most expensive always-loaded sources with numbers, and one habitual read has demonstrably moved (the session start no longer contains it).
+
+## Measure it
+
+[`ghost_token_counter.py`](../samples/scripts/ghost_token_counter.py) is the per-source baseline with history; [`token_report.py`](../samples/scripts/token_report.py) reads real spend per session. The [context carry-cost calculator](https://jamesross.ai/tools/context-cost.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) prices a read by position if you want the intuition before the instrument.
+
+Next: [M3. Verification & oversight](03-verification-oversight.md).

--- a/learn/03-verification-oversight.md
+++ b/learn/03-verification-oversight.md
@@ -1,0 +1,26 @@
+# M3. Verification & oversight — trust through checks
+
+> [Learn track](README.md) · dimension: **Verification & oversight** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+An agent workspace accumulates two kinds of change nobody verifies by default: changes to the workspace (configs drift, hooks stop firing, memory contradicts reality) and changes *by* the workspace to itself (a better-worded skill, a folded-in lesson, a new reasoning rule). Both feel fine right up until they aren't. The shared discipline: nothing is adopted on the strength of how good it sounds. A change earns its place through a check that could have rejected it.
+
+That cuts both ways. Most "make the agent smarter" additions — a second same-model pass, an always-on critic — never get checked either, and some degrade the result while costing tokens. The gate applies to the scaffolding you add, not just the edits the agent proposes.
+
+## The patterns
+
+- [**Pattern 8. Audit the workspace like a fitness function**](../PATTERNS.md#8-audit-the-workspace-like-a-fitness-function) — a scheduled auditor with canaries that prove it still detects known-bad fixtures, a finding ledger, and deliberately no single numeric score.
+- [**Pattern 10. A skill is editable weights**](../PATTERNS.md#10-a-skill-is-editable-weights--never-adopt-a-self-edit-without-a-gate) — a proposed instruction edit is staged, reviewed, then adopted. The published cautionary case: an ungated self-edit loop collapsed its own benchmark score 0.554 → 0.026.
+- [**Pattern 11. A scaffold is a hypothesis**](../PATTERNS.md#11-a-scaffold-is-a-hypothesis--gate-it-behind-a-measurable-signal) — register every capability addition with a falsifiable hypothesis and a review date; beat baseline or get cut. Removal is a first-class outcome.
+- [**Pattern 13. Challenge half-formed ideas with a different lens**](../PATTERNS.md#13-challenge-half-formed-ideas-with-a-different-lens--and-hold-a-sample-back-to-prove-it-helps) — one grounded divergent challenge on real forks, with a held-out sample so the aid stays measurable.
+
+## Do this
+
+Two artefacts, an hour total. (1) Write one **golden case**: a prompt your workspace handles regularly, plus the deterministically checkable property a good answer must have (a file cited, a figure matched, a rule applied). (2) Pick one scaffold you've added — any always-loaded rule or skill — and write its register row: what it should improve, how that would be measured, and a review date at which it beats baseline or gets cut.
+
+**Done-check:** both exist as files, and the register row's hypothesis is falsifiable — someone else could run the check and tell you the scaffold failed.
+
+## Measure it
+
+The audit machinery in [`samples/.claude/agents/audit.md`](../samples/.claude/agents/audit.md) shows the full shape: cadence, canaries, tiered findings. Your golden case is its seed — one case is a smoke test, twenty is a regression suite.
+
+Next: [M4. Safety & permissions](04-safety-permissions.md).

--- a/learn/03-verification-oversight.md
+++ b/learn/03-verification-oversight.md
@@ -1,6 +1,6 @@
 # M3. Verification & oversight — trust through checks
 
-> [Learn track](README.md) · dimension: **Verification & oversight** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Verification & oversight** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 An agent workspace accumulates two kinds of change nobody verifies by default: changes to the workspace (configs drift, hooks stop firing, memory contradicts reality) and changes *by* the workspace to itself (a better-worded skill, a folded-in lesson, a new reasoning rule). Both feel fine right up until they aren't. The shared discipline: nothing is adopted on the strength of how good it sounds. A change earns its place through a check that could have rejected it.
 

--- a/learn/04-safety-permissions.md
+++ b/learn/04-safety-permissions.md
@@ -1,6 +1,6 @@
 # M4. Safety & permissions — cheap mechanical guards
 
-> [Learn track](README.md) · dimension: **Safety & permissions** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Safety & permissions** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 "Be more careful" does not scale to an agent that runs hundreds of tool calls a day. What scales is a small set of deterministic guards that intercept the casual failure modes — an output redirect over your `.env`, a force-push, a delete aimed one folder too high — before they run. The guards are mistake-catchers, not security boundaries: a determined process writing files from inside Python is out of scope, and that honesty matters, because a guard you believe is a boundary is worse than no guard.
 

--- a/learn/04-safety-permissions.md
+++ b/learn/04-safety-permissions.md
@@ -1,0 +1,25 @@
+# M4. Safety & permissions — cheap mechanical guards
+
+> [Learn track](README.md) · dimension: **Safety & permissions** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+"Be more careful" does not scale to an agent that runs hundreds of tool calls a day. What scales is a small set of deterministic guards that intercept the casual failure modes — an output redirect over your `.env`, a force-push, a delete aimed one folder too high — before they run. The guards are mistake-catchers, not security boundaries: a determined process writing files from inside Python is out of scope, and that honesty matters, because a guard you believe is a boundary is worse than no guard.
+
+The companion instinct is routing by consequence. Decide what may happen automatically by what an action *costs if wrong* — mechanical reversibility — never by how confident the request sounds. And keep the one class of damage no hook can undo, leaked credentials, out of files entirely.
+
+## The patterns
+
+- [**Pattern 7. A cheap hook beats a careful agent**](../PATTERNS.md#7-a-cheap-hook-beats-a-careful-agent) — a pre-execution hook string-matches tool calls against a blocklist and fails open; a ten-line check catches most accidental damage for almost nothing.
+- [**Pattern 4. Tier by mechanical impact, not by tone**](../PATTERNS.md#4-tier-by-mechanical-impact-not-by-tone) — auto-apply the trivially reversible; human-gate anything that deletes, publishes, or spends.
+- [**Pattern 6. Credentials live in one place, never in files**](../PATTERNS.md#6-credentials-live-in-one-place-never-in-files) — a password manager is the single store; files carry item *names*; runtime resolves values and scrubs them.
+
+## Do this
+
+Install the two guards from the [starter template](https://github.com/jimy-r/agent-workspace-starter?utm_source=github&utm_medium=repo&utm_campaign=learn-track) (or wire your own equivalents): the file-protection hook and the bash-command hook, plus a `protected-paths.txt` naming what the agent must never write. Then **live-fire them**: ask the agent to append a line to a protected test file, and to push to a protected branch of a scratch repo. Watch both get blocked.
+
+**Done-check:** two deliberate violations attempted, two blocks observed. A hook that has never fired on a known-bad input is configuration, not protection.
+
+## Measure it
+
+The live-fire *is* the measurement — repeat it whenever the hook config changes. For the credential rule, grep your workspace for anything shaped like a secret (`sk-`, `token`, `Bearer`): the count should be zero values, any number of item names.
+
+Next: [M5. Telemetry & cost](05-telemetry-cost.md).

--- a/learn/05-telemetry-cost.md
+++ b/learn/05-telemetry-cost.md
@@ -1,6 +1,6 @@
 # M5. Telemetry & cost — loud failure, priced lanes
 
-> [Learn track](README.md) · dimension: **Telemetry & cost** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Telemetry & cost** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 The whole point of a scheduled task is that nobody is watching it — which is exactly why nobody notices when it dies. The worked failure behind this module: a morning-brief lane in a real workspace failed on an expired credential for **34 consecutive days**, wrapper exiting cleanly the whole time, alarms firing into channels whose only readers were the dead systems themselves. Detection isn't remediation, and an alarm needs a live human reader.
 

--- a/learn/05-telemetry-cost.md
+++ b/learn/05-telemetry-cost.md
@@ -1,0 +1,26 @@
+# M5. Telemetry & cost — loud failure, priced lanes
+
+> [Learn track](README.md) · dimension: **Telemetry & cost** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+The whole point of a scheduled task is that nobody is watching it — which is exactly why nobody notices when it dies. The worked failure behind this module: a morning-brief lane in a real workspace failed on an expired credential for **34 consecutive days**, wrapper exiting cleanly the whole time, alarms firing into channels whose only readers were the dead systems themselves. Detection isn't remediation, and an alarm needs a live human reader.
+
+The cost half is the same instinct pointed at spend. Before any structural cost fix (cheaper models, new infrastructure), instrument: split consumption by lane, token class, and model, then pull configuration levers cheapest-first, one variable at a time. In the measured case, the migration that nearly shipped would have forfeited a 95% cache-hit subsidy that no price list shows.
+
+## The patterns
+
+- [**Pattern 3. Make silent failure loud (the dead-man's switch)**](../PATTERNS.md#3-make-silent-failure-loud-the-dead-mans-switch) — every scheduled task emits a success sentinel; a watchdog raises a finding when the sentinel is missing or stale. Self-hosted, no uptime service.
+- [**Pattern 15. Price the lane before you migrate it**](../PATTERNS.md#15-price-the-lane-before-you-migrate-it) — walk the transcripts before believing any per-token price list; run each cost lever as a registered trial with a kill criterion.
+
+Cross-reference: the always-loaded baseline and its trend alarm live in [M2](02-context-economics.md) (Pattern 9).
+
+## Do this
+
+Pick your one scheduled or recurring automated task (backup, digest, sync — anything unattended). Give it a sentinel: on success it writes a dated marker line to a log. Add a freshness check that runs somewhere a human actually looks — session start is the honest choice — and flags when the marker is older than the task's cadence plus slack.
+
+**Done-check:** kill the task deliberately (disable it for a cycle) and confirm the staleness flag surfaces where you'd genuinely see it. An alarm you had to go looking for fails the check.
+
+## Measure it
+
+[`check_task_freshness.py`](../samples/scripts/check_task_freshness.py) is the watchdog shape; [`tier_metrics.py`](../samples/scripts/tier_metrics.py) is the lane-split spend instrument. Instrument the artefact the task produces, not the wrapper's exit code — a wrapper can exit 0 with nothing written.
+
+Next: [M6. Provenance & delegation](06-provenance-delegation.md).

--- a/learn/05-telemetry-cost.md
+++ b/learn/05-telemetry-cost.md
@@ -21,6 +21,6 @@ Pick your one scheduled or recurring automated task (backup, digest, sync — an
 
 ## Measure it
 
-[`check_task_freshness.py`](../samples/scripts/check_task_freshness.py) is the watchdog shape; [`tier_metrics.py`](../samples/scripts/tier_metrics.py) is the lane-split spend instrument. Instrument the artefact the task produces, not the wrapper's exit code — a wrapper can exit 0 with nothing written.
+[`check_task_freshness.py`](../samples/scripts/security/check_task_freshness.py) is the watchdog shape; [`tier_metrics.py`](../samples/scripts/tier_metrics.py) is the lane-split spend instrument. Instrument the artefact the task produces, not the wrapper's exit code — a wrapper can exit 0 with nothing written.
 
 Next: [M6. Provenance & delegation](06-provenance-delegation.md).

--- a/learn/06-provenance-delegation.md
+++ b/learn/06-provenance-delegation.md
@@ -1,0 +1,26 @@
+# M6. Provenance & delegation — sourced claims, mandated work
+
+> [Learn track](README.md) · dimension: **Provenance & delegation** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+
+Two questions decide whether you can trust work you didn't watch happen. For any claim: *what is this standing on, and could I tell if the answer were nothing?* For any autonomous act: *who authorised this, and would they recognise the mandate?* A workspace that can't answer the first hands you confident sentences with nothing behind them. One that can't answer the second either nags you about everything or acts on guesses.
+
+The delegation half carries this repo's most instructive negative result: a background agent that discovered its own work from the task list was retired after its clarifying questions piled up thirteen deep in a file nobody read, while its scheduled runtime failed dark for five weeks on an expired credential. What replaced it inverts the direction of authorisation — work reaches the agent only when a human marks it delegated, capturing intent while it's still in their head.
+
+## The patterns
+
+- [**Pattern 16. A claim carries its provenance, or it is a guess**](../PATTERNS.md#16-a-claim-carries-its-provenance-or-it-is-a-guess) — cite `path:line` for state claims; grade source and credibility visibly; record what would falsify a durable brief. Scope: load-bearing claims only.
+- [**Pattern 14. Delegation is a queue you fill, not work the agent finds**](../PATTERNS.md#14-delegation-is-a-queue-you-fill-not-work-the-agent-finds) — a delegated card carries done-when, write boundaries, and pre-ruled forks; questions go on the card, not into a side channel.
+- [**Pattern 2. Classify-then-act, not ask-then-wait**](../PATTERNS.md#2-classify-then-act-not-ask-then-wait) — where a mandate *is* unambiguous: build the has-default work speculatively, lodge for review, log every rejection.
+- [**Pattern 12. Loop selection: not everything should be a loop**](../PATTERNS.md#12-loop-selection-not-everything-should-be-a-loop) — the four-box test (recurring, mechanically verifiable, low-judgment, headless) plus an irreversibility override that caps outward acts at surface-level autonomy.
+
+## Do this
+
+Two passes. (1) Run the **four-box test** on three tasks you're tempted to automate; expect at least one to come out *surface* or *keep manual* — if all three score *loop*, re-check box 3 honestly. (2) Delegate one real task properly: write the card with what done looks like, where the agent may write, and how its most likely fork should be ruled.
+
+**Done-check:** the three verdicts are written down with the failing box named, and the delegated card's done-when is checkable by someone who didn't write it.
+
+## Measure it
+
+[`wrap_drift_scan.py`](../samples/scripts/wrap_drift_scan.py) is the worked *surface* case (read-only close-out scan). For provenance, sample five load-bearing claims from your agent's last substantive answer: each should carry a source or an honest `[unverified]`. Count the ones that don't.
+
+End of track. Retake the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and diff against your M0 baseline — that diff is the track's own done-check.

--- a/learn/06-provenance-delegation.md
+++ b/learn/06-provenance-delegation.md
@@ -1,6 +1,6 @@
 # M6. Provenance & delegation — sourced claims, mandated work
 
-> [Learn track](README.md) · dimension: **Provenance & delegation** in the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
+> [Learn track](README.md) · dimension: **Provenance & delegation** in the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track).
 
 Two questions decide whether you can trust work you didn't watch happen. For any claim: *what is this standing on, and could I tell if the answer were nothing?* For any autonomous act: *who authorised this, and would they recognise the mandate?* A workspace that can't answer the first hands you confident sentences with nothing behind them. One that can't answer the second either nags you about everything or acts on guesses.
 
@@ -23,4 +23,4 @@ Two passes. (1) Run the **four-box test** on three tasks you're tempted to autom
 
 [`wrap_drift_scan.py`](../samples/scripts/wrap_drift_scan.py) is the worked *surface* case (read-only close-out scan). For provenance, sample five load-bearing claims from your agent's last substantive answer: each should carry a source or an honest `[unverified]`. Count the ones that don't.
 
-End of track. Retake the [maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and diff against your M0 baseline — that diff is the track's own done-check.
+End of track. Retake the [maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track) and diff against your M0 baseline — that diff is the track's own done-check.

--- a/learn/README.md
+++ b/learn/README.md
@@ -6,7 +6,7 @@ This is the *learning order*. [ADOPTION.md](../ADOPTION.md) is the *installation
 
 ## Where to start
 
-Take the [workspace maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) — 18 questions, scored across the same six dimensions as these modules. Your weakest dimension is your first module. No time for that? Start at [M0](00-foundations.md) and go in order.
+Take the [workspace maturity check](https://jamesross.ai/tools/maturity-check?utm_source=github&utm_medium=repo&utm_campaign=learn-track) — 18 questions, scored across the same six dimensions as these modules. Your weakest dimension is your first module. No time for that? Start at [M0](00-foundations.md) and go in order.
 
 If you'd rather build than read, take the hands-on companion track — [stand up a working workspace from the starter template](https://github.com/jimy-r/agent-workspace-starter/blob/main/docs/tutorial.md) — then come back here for the why.
 

--- a/learn/README.md
+++ b/learn/README.md
@@ -1,0 +1,31 @@
+# Learn the architecture
+
+A guided track through the [patterns](../PATTERNS.md), organised around the six capabilities a governed agent workspace needs. Each module explains why one capability matters, points at the patterns that build it, and ends with an exercise you can complete in your own workspace the same day.
+
+This is the *learning order*. [ADOPTION.md](../ADOPTION.md) is the *installation order* — what to set up first when you're standing up a workspace. The two differ because the thing worth understanding first (why claims need provenance) is rarely the thing worth installing first (a file-protection hook). Read here, install there.
+
+## Where to start
+
+Take the [workspace maturity check](https://jamesross.ai/tools/maturity-check.html?utm_source=github&utm_medium=repo&utm_campaign=learn-track) — 18 questions, scored across the same six dimensions as these modules. Your weakest dimension is your first module. No time for that? Start at [M0](00-foundations.md) and go in order.
+
+If you'd rather build than read, take the hands-on companion track — [stand up a working workspace from the starter template](https://github.com/jimy-r/agent-workspace-starter/blob/main/docs/tutorial.md) — then come back here for the why.
+
+## The modules
+
+| Module | Capability | Patterns | You will |
+|---|---|---|---|
+| [M0. Foundations](00-foundations.md) | the session loop | — | run orient → plan → work → wrap once |
+| [M1. Canonical knowledge](01-canonical-knowledge.md) | one source of truth | 1, 5, 17 | collapse a duplicated rule into a canonical copy + pointers |
+| [M2. Context economics](02-context-economics.md) | context as spend | 9, 18 | measure your always-loaded surface; move one bulk read out |
+| [M3. Verification & oversight](03-verification-oversight.md) | trust through checks | 8, 10, 11, 13 | write a golden case; register a scaffold with a review date |
+| [M4. Safety & permissions](04-safety-permissions.md) | cheap mechanical guards | 4, 6, 7 | install two hooks and live-fire them on a safe target |
+| [M5. Telemetry & cost](05-telemetry-cost.md) | loud failure, priced lanes | 3, 15 | put a dead-man's switch on one scheduled task |
+| [M6. Provenance & delegation](06-provenance-delegation.md) | claims that carry sources; work that carries mandates | 2, 12, 14, 16 | run the four-box test; delegate one card properly |
+
+Every pattern in [PATTERNS.md](../PATTERNS.md) appears in exactly one module and is cross-referenced where it touches others. The modules stay short on purpose: the patterns file carries the reasoning, the samples carry the implementation, and these pages carry the path through them.
+
+## How each module works
+
+**Read** the module page (five minutes). **Do** the exercise — each has a done-check you can verify mechanically, not a "reflect on" prompt. **Measure** with the named instrument, so you know the exercise took. A module without its exercise done is a module read, not learned.
+
+Questions and corrections go to [issues](https://github.com/jimy-r/agent-workspace-architecture/issues). If an exercise doesn't survive contact with your workspace, that's a defect in the exercise — report it.


### PR DESCRIPTION
Adds `learn/` — a guided 7-module track through the 18 patterns, organised by the six maturity dimensions, one exercise with a done-check per module. README reading-map row, CHANGELOG entry, llms-full regenerated. Hands-on companion tutorial ships in the starter repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)