### PR TITLE
chore: refresh the llms-full.txt freshness stamp in the sitemap

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Follow-up to #141: docs/llms-full.txt was regenerated there and docs/sitemap.xml still stamped it 2026-09-06, which the freshness check flagged on the merge. Fixed with scripts/check_freshness.py --fix; the check now passes locally. No redaction-relevant content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)