### PR TITLE
fix: correct the discovery files and the redaction instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,12 @@ financial or legal data, and absolute paths that reveal a machine layout. Use
 the generic placeholders the repo already uses: `<workspace>`, `<home>`,
 `<project>`, "the user".
 
-Run the scanner before every commit:
-
-```bash
-python scripts/redaction_check.py
-```
+The automated gate runs in CI, not locally. `redaction-check.yml` calls the
+scanner published as
+[`jimy-r/redaction-check-action`](https://github.com/jimy-r/redaction-check-action),
+and that is the check branch protection requires on every pull request. No
+copy of the scanner ships in this repo, so the pre-commit step is the manual
+scrub above.
 
 When in doubt, generalise. A leak survives amendment because the push already
 happened.
@@ -54,16 +55,18 @@ happened.
 ## Checks to run before you commit
 
 ```bash
-python scripts/redaction_check.py       # privacy gate, always
 python scripts/validate_samples.py      # sample frontmatter, links, schemas
 python scripts/gen_llms_full.py --check # llms-full.txt matches its sources
 python scripts/check_freshness.py       # dated stamps match git history
 python tools/workspace_check.py --self-test
+# redaction runs in CI (redaction-check.yml); there is no local script
 ```
 
 Regenerate rather than hand-edit: `python scripts/gen_llms_full.py` rewrites
 `docs/llms-full.txt`, and `python scripts/check_freshness.py --fix` rewrites the
-dated stamps. CI runs the same commands, so a green local run is the gate.
+dated stamps. CI runs these same commands, so a green local run is the gate
+for all of them. Redaction is the exception: it has no local script and runs
+only in CI.
 
 ## Conventions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Do **not** include the leaked content in the report. Link to the file and line.
 
 ### 2. Vulnerabilities in the GitHub Actions workflows
 
-The repo runs workflows (`redaction-check` — the branch-protection-required gate — plus `link-check`, `docs-consistency`, `mermaid-check`, `llms-full-check`, `stale`, `validate-samples`, `dependabot`, `labeler`, `lock-closed`) under the repo's `GITHUB_TOKEN`. If you spot an injection risk, permission escalation path, or supply-chain concern in any of these:
+The repo runs workflows (`redaction-check` — the branch-protection-required gate — plus `link-check`, `docs-consistency`, `freshness-check`, `mermaid-check`, `llms-full-check`, `stale`, `validate-samples`, `dependabot`, `labeler`, `lock-closed`) under the repo's `GITHUB_TOKEN`. If you spot an injection risk, permission escalation path, or supply-chain concern in any of these:
 
 - Use **GitHub's [private security advisories](https://github.com/jimy-r/agent-workspace-architecture/security/advisories/new)** — not a public Issue.
 - Maintainer will triage and coordinate a fix before public disclosure.

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,7 @@
 <!-- Plain-text views of the same reference, for models that read llms.txt. -->
 <link rel="alternate" type="text/plain" href="llms.txt" title="llms.txt — link map of the reference">
 <link rel="alternate" type="text/plain" href="llms-full.txt" title="llms-full.txt — the whole reference inlined">
+<link rel="describedby" type="text/plain" href="llms.txt">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -31,7 +32,7 @@
   "url": "https://jimy-r.github.io/agent-workspace-architecture/",
   "mainEntityOfPage": "https://jimy-r.github.io/agent-workspace-architecture/",
   "image": "https://jimy-r.github.io/agent-workspace-architecture/assets/social-card.png",
-  "dateModified": "2026-09-06",
+  "dateModified": "2026-09-13",
   "inLanguage": "en",
   "license": "https://opensource.org/licenses/MIT",
   "author": {
@@ -465,7 +466,7 @@
     <a href="llms-full.txt">llms-full.txt</a>
     <a href="https://jamesross.ai/?utm_source=tour&amp;utm_medium=footer&amp;utm_campaign=flagship">jamesross.ai</a>
     <a href="https://jimyr.substack.com/?utm_source=tour&amp;utm_medium=footer&amp;utm_campaign=flagship">Follow on Substack</a>
-    <span id="last-updated">Last updated: 2026-09-06</span><script>try{var d=new Date(document.lastModified);if(!isNaN(d)){document.getElementById("last-updated").textContent="Last updated: "+d.toISOString().slice(0,10);}}catch(e){}</script>
+    <span id="last-updated">Last updated: 2026-09-13</span><script>try{var d=new Date(document.lastModified);if(!isNaN(d)){document.getElementById("last-updated").textContent="Last updated: "+d.toISOString().slice(0,10);}}catch(e){}</script>
   </div>
 </footer>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,12 +4,12 @@
 
 ## Full text
 
-- [llms-full.txt](https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt): The six core documents (README, PATTERNS, META_ARCHITECTURE, EVALUATION, ADOPTION, WORKFLOW) inlined in reading order; the tour, changelog, and samples are linked only. Read this instead of following the links if you want the core reference in one request.
+- [llms-full.txt](https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt): The six core documents (README, PATTERNS, META_ARCHITECTURE, EVALUATION, ADOPTION, WORKFLOW) inlined in reading order; the tour, changelog, and samples are linked only. Read this instead of following the links if you want the core reference in one request. Start here.
 
 ## Source documents
 
-- [Tour](https://jimy-r.github.io/agent-workspace-architecture/): The interactive tour — layers, modules, patterns, and a task walkthrough. Start here.
-- [The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html): The entire architecture on one page — entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer.
+- [Tour](https://jimy-r.github.io/agent-workspace-architecture/): The interactive tour — layers, modules, patterns, and a task walkthrough. An HTML page: for the same material in markdown, read PATTERNS.md below.
+- [The workspace, mapped](https://jimy-r.github.io/agent-workspace-architecture/workspace-map.html): The entire architecture on one page — entry points, the session, the governance floor, persistent state, gated outputs, and the watcher layer. An HTML page built around an inline SVG diagram, so it degrades badly in text extraction: for the same material in markdown, read META_ARCHITECTURE.md below.
 - [PATTERNS.md](https://github.com/jimy-r/agent-workspace-architecture/blob/main/PATTERNS.md): The eighteen load-bearing patterns, each as problem, pattern, why it beats the obvious alternative, and what it costs.
 - [META_ARCHITECTURE.md](https://github.com/jimy-r/agent-workspace-architecture/blob/main/META_ARCHITECTURE.md): The full structural map of the workspace: layers, modules, personas, routines, hooks, MCP servers, memory, and the task layer.
 - [EVALUATION.md](https://github.com/jimy-r/agent-workspace-architecture/blob/main/EVALUATION.md): How to tell whether a workspace change actually helped. A golden set of frozen cases replayed K times, deterministic checks rather than an LLM judge, and the five-class fixture discipline that validates a check.
@@ -32,6 +32,7 @@
 ## Teardowns
 
 - [teardowns/README.md](https://github.com/jimy-r/agent-workspace-architecture/blob/main/teardowns/README.md): The teardown index, ground rules, and page conventions. Published architectures read against the eighteen patterns.
+- [GPT-RAG](https://github.com/jimy-r/agent-workspace-architecture/blob/main/teardowns/2026-09-06-azure-gpt-rag.md): Microsoft's Foundry solution accelerator, read at `76a8a4d6fd88`. Decision records that carry an expiry date and falsifiers; the absences cluster on execution — ~300 KB of tests no workflow runs.
 - [DeepSeek Harness](https://github.com/jimy-r/agent-workspace-architecture/blob/main/teardowns/2026-09-05-deepseek-harness.md): DeepSeek's plugin-everything agent runtime, read at `d347e703908d`. Strong on one-home-per-fact and guards proven to fail; no first-party memory, by recorded decision.
 - [herdr](https://github.com/jimy-r/agent-workspace-architecture/blob/main/teardowns/2026-08-28-herdr.md): The Rust runtime that owns the terminals coding agents live in, read at `7b675f42af35`. Pane state and agent-native coordination are ahead of the field; spend, freshness, and provenance are unaccounted.
 - [LifeOS](https://github.com/jimy-r/agent-workspace-architecture/blob/main/teardowns/2026-08-28-lifeos.md): A personal AI operating layer shipped as one self-contained skill, read at `ce046f26495c`. Distribution discipline is exemplary; measurement, silent-failure detection, and provenance are absent.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://jimy-r.github.io/agent-workspace-architecture/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://jimy-r.github.io/agent-workspace-architecture/llms.txt</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/learn/README.md
+++ b/learn/README.md
@@ -28,7 +28,7 @@ Every pattern in [PATTERNS.md](../PATTERNS.md) appears in exactly one module and
 
 ## How each module works
 
-**Read** the module page (five minutes). **Do** the exercise — each has a done-check you can verify mechanically, not a "reflect on" prompt. **Measure** with the named instrument, so you know the exercise took. **Record** the done-check somewhere outside your own head. A module without its exercise done is a module read, not learned.
+**Read** the module page (five minutes). **Do** the exercise — most done-checks are mechanical rather than a "reflect on" prompt, and two are not: M2 asks you to name your three costliest always-loaded sources, which is a self-report, and M6 asks whether a delegated card's done-when is checkable by someone who did not write it, which needs a second reader. **Measure** with the named instrument, so you know the exercise took. **Record** the done-check somewhere outside your own head. A module without its exercise done is a module read, not learned.
 
 ## Track your progress
 


### PR DESCRIPTION
Six audit findings from the 2026-09-13 drain, all fact corrections in the discovery and instruction files. No behaviour change.

| Finding | File | Change |
|---|---|---|
| `c235cd61` | `AGENTS.md` | Drops the two `scripts/redaction_check.py` invocations (the script left the repo the day AGENTS.md arrived) and states that the redaction gate runs in CI through `jimy-r/redaction-check-action`. |
| `2572450c` | `SECURITY.md` | Adds `freshness-check` to the workflow inventory; it was added in the 2026-09-06 batch that fixed the previous omission. |
| `7782aa7c` | `docs/llms.txt` | Adds the GPT-RAG teardown (the v1.16.0 headline and the only Microsoft subject) to the Teardowns block. |
| `64602ce5` | `docs/llms.txt` | The tour and map entries now name their markdown equivalents, so an agent following llms.txt is not handed HTML without warning. |
| `bef33998` | `docs/index.html` | Adds `rel="describedby"` for llms.txt beside the existing `rel="alternate"` links. |
| `73bfe5ea` | `learn/README.md` | Corrects the claim that every done-check is mechanical: two (M2, M6) are self-reports, and the line now says so. |

Local checks: validate_samples, gen_llms_full --check, check_freshness, workspace_check --self-test, pattern-count (18), role-count (17), redaction grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
