### PR TITLE
chore: gate three hand-maintained claims and fix the link-rot signal

### DIFF
--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -3,6 +3,11 @@ name: Docs consistency
 # Gates the pattern-count claims against PATTERNS.md itself (audit finding
 # 570ab6e2: the tour advertised 14/fifteen patterns while PATTERNS.md carried
 # seventeen). The count is derived, never hand-maintained here.
+#
+# The same principle now covers three more hand-maintained claims: the learn
+# track's partition of the patterns (14874284), docs/llms.txt's coverage of
+# the teardown and learn pages (7782aa7c, which lost a teardown), and
+# SECURITY.md's workflow inventory (2572450c, which lost a workflow twice).
 
 on:
   pull_request:
@@ -14,7 +19,11 @@ on:
       - 'docs/workspace-map.html'
       - 'samples/README.md'
       - 'samples/roles/**'
-      - '.github/workflows/docs-consistency.yml'
+      - 'learn/**'
+      - 'teardowns/**'
+      - 'docs/llms.txt'
+      - 'SECURITY.md'
+      - '.github/workflows/**'
   push:
     branches: [main]
     paths:
@@ -25,6 +34,11 @@ on:
       - 'docs/workspace-map.html'
       - 'samples/README.md'
       - 'samples/roles/**'
+      - 'learn/**'
+      - 'teardowns/**'
+      - 'docs/llms.txt'
+      - 'SECURITY.md'
+      - '.github/workflows/**'
 
 permissions:
   contents: read
@@ -119,4 +133,113 @@ jobs:
           if errors:
               sys.exit("\n".join(errors))
           print(f"OK: every numeric role claim matches samples/roles/ ({n} / '{word}')")
+          EOF
+
+  pattern-partition:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Learn modules partition PATTERNS.md exactly once
+        run: |
+          python3 - <<'EOF'
+          import re, sys
+          from pathlib import Path
+
+          patterns = {int(m) for m in re.findall(
+              r"(?m)^## (\d+)\. ", Path("PATTERNS.md").read_text(encoding="utf-8"))}
+          if not patterns:
+              sys.exit("PATTERNS.md has zero '## N. <title>' headings - heading format changed?")
+
+          lines = Path("learn/README.md").read_text(encoding="utf-8").splitlines()
+
+          def cells(row):
+              return [c.strip() for c in row.strip().strip("|").split("|")]
+
+          # Find the module table's header and the index of its Patterns column,
+          # so a column reorder fails loudly instead of reading the wrong cell.
+          col = None
+          for line in lines:
+              if line.startswith("| Module "):
+                  head = [c.lower() for c in cells(line)]
+                  if "patterns" in head:
+                      col = head.index("patterns")
+                  break
+          if col is None:
+              sys.exit("learn/README.md: no module table header with a 'Patterns' column")
+
+          rows = [l for l in lines if l.startswith("| [M")]
+          if not rows:
+              sys.exit("learn/README.md has no '| [Mn. ...]' module rows - table shape changed?")
+
+          assigned = []
+          for row in rows:
+              cell = cells(row)[col]
+              if cell in ("", "-", "\u2014"):
+                  continue
+              for token in cell.split(","):
+                  token = token.strip()
+                  if not token.isdigit():
+                      sys.exit(f"learn/README.md: unparseable pattern token {token!r} in: {row}")
+                  assigned.append(int(token))
+
+          errors = []
+          dupes = sorted({n for n in assigned if assigned.count(n) > 1})
+          if dupes:
+              errors.append(f"patterns assigned to more than one module: {dupes}")
+          missing = sorted(patterns - set(assigned))
+          if missing:
+              errors.append(f"patterns in PATTERNS.md that no module covers: {missing}")
+          extra = sorted(set(assigned) - patterns)
+          if extra:
+              errors.append(f"modules cite patterns PATTERNS.md does not have: {extra}")
+          if errors:
+              sys.exit("\n".join(errors))
+          print(f"OK: {len(rows)} modules partition all {len(patterns)} patterns, no duplicates")
+          EOF
+
+  llms-txt-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Every teardown and learn page is in docs/llms.txt
+        run: |
+          python3 - <<'EOF'
+          import sys
+          from pathlib import Path
+
+          llms = Path("docs/llms.txt").read_text(encoding="utf-8")
+          pages = sorted(
+              p.as_posix()
+              for d in ("teardowns", "learn")
+              for p in Path(d).glob("*.md")
+          )
+          if not pages:
+              sys.exit("teardowns/ and learn/ hold no .md pages - directories moved?")
+          missing = [p for p in pages if p not in llms]
+          if missing:
+              sys.exit("docs/llms.txt references neither the path nor a URL for:\n  "
+                       + "\n  ".join(missing))
+          print(f"OK: all {len(pages)} teardown and learn pages are referenced in docs/llms.txt")
+          EOF
+
+  security-workflow-inventory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Every workflow is named in SECURITY.md
+        run: |
+          python3 - <<'EOF'
+          import sys
+          from pathlib import Path
+
+          security = Path("SECURITY.md").read_text(encoding="utf-8")
+          names = sorted({p.stem for p in Path(".github/workflows").glob("*.yml")}
+                         | {p.stem for p in Path(".github/workflows").glob("*.yaml")})
+          if not names:
+              sys.exit(".github/workflows/ holds no workflow files - directory moved?")
+          missing = [n for n in names if f"`{n}`" not in security]
+          if missing:
+              sys.exit("SECURITY.md's workflow inventory does not name:\n  "
+                       + "\n  ".join(missing))
+          print(f"OK: all {len(names)} workflows are named in SECURITY.md")
           EOF

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -104,6 +104,11 @@ jobs:
           issue-number: ${{ steps.standing.outputs.number }}
           title: ${{ env.ISSUE_TITLE }}
           content-filepath: ./lychee/out.md
+          # link-rot is exempted in stale.yml. Without it the standing issue goes
+          # stale after 60 quiet days - the healthy case - auto-closes, and the
+          # --state open lookup above then files a duplicate on the next real
+          # failure instead of refreshing this one.
           labels: |
             ci
             docs
+            link-rot

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,6 +35,6 @@ jobs:
           close-pr-message: >
             Closing due to inactivity. Reopen anytime when ready to pick it
             back up.
-          exempt-issue-labels: 'pinned,moderation,blocked'
+          exempt-issue-labels: 'pinned,moderation,blocked,link-rot'
           exempt-pr-labels: 'pinned,blocked,work-in-progress'
           operations-per-run: 100

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # agent-workspace-architecture
 
 [![Redaction check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/redaction-check.yml?label=redaction)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/redaction-check.yml)
-[![Link check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/link-check.yml?label=links)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/link-check.yml)
+[![Link check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/link-check.yml?label=links&event=pull_request)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/link-check.yml)
 [![Validate samples](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/validate-samples.yml?label=samples)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/validate-samples.yml)
 
 A reference implementation of **agent-ready knowledge architecture**: the roles, routines, hooks, skills, memory, and task coordination that make a body of working knowledge legible to AI agents, and turn a coding agent into a system you can hand work to and trust to make progress while you're away.
@@ -120,4 +120,4 @@ The repo was renamed from `claude-workspace-architecture` on 2026-05-28; the old
 
 ---
 
-*Last verified against the repo structure on 2026-09-06.*
+*Last verified against the repo structure on 2026-09-13.*

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -150,7 +150,7 @@ The repo was renamed from `claude-workspace-architecture` on 2026-05-28; the old
 
 ---
 
-*Last verified against the repo structure on 2026-09-06.*
+*Last verified against the repo structure on 2026-09-13.*
 
 
 ==============================================================================

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31,7 +31,7 @@ URL: https://github.com/jimy-r/agent-workspace-architecture/blob/main/README.md
 # agent-workspace-architecture
 
 [![Redaction check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/redaction-check.yml?label=redaction)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/redaction-check.yml)
-[![Link check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/link-check.yml?label=links)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/link-check.yml)
+[![Link check](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/link-check.yml?label=links&event=pull_request)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/link-check.yml)
 [![Validate samples](https://img.shields.io/github/actions/workflow/status/jimy-r/agent-workspace-architecture/validate-samples.yml?label=samples)](https://github.com/jimy-r/agent-workspace-architecture/actions/workflows/validate-samples.yml)
 
 A reference implementation of **agent-ready knowledge architecture**: the roles, routines, hooks, skills, memory, and task coordination that make a body of working knowledge legible to AI agents, and turn a coding agent into a system you can hand work to and trust to make progress while you're away.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://jimy-r.github.io/agent-workspace-architecture/llms-full.txt</loc>
-    <lastmod>2026-09-09</lastmod>
+    <lastmod>2026-09-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Four audit findings from the 2026-09-13 drain. CI and one badge URL; the only reader-visible change is the badge.

| Finding | File | Change |
|---|---|---|
| `506167c6` | `link-check.yml`, `stale.yml` | The standing link-check issue gains a `link-rot` label, and `stale.yml` exempts it. It carried only `ci` and `docs`, neither exempt, so 60 quiet days (the healthy case) would mark it stale, close it 14 days later, and the `--state open` lookup would then file a duplicate on the next real failure instead of refreshing the one already open. |
| `b13fa084` | `README.md:4` | The links badge gains `&event=pull_request`. `shields.io/.../workflow/status` renders the run conclusion, and the scheduled full-repo arm passes `fail: false` deliberately, so the badge stayed green through a 2-error sweep. Scoping it to the PR arm points it at the half that can fail. The scheduled arm keeps reporting through its issue. |
| `14874284` | `docs-consistency.yml` | New `pattern-partition` job. `learn/README.md` claims every pattern appears in exactly one module; the claim is true today and nothing checked it. Same derive-from-source shape as the existing count jobs. |
| `7782aa7c` / `2572450c` | `docs-consistency.yml` | Two class-closers: `llms-txt-coverage` (every `teardowns/*.md` and `learn/*.md` is referenced in `docs/llms.txt`) and `security-workflow-inventory` (every `.github/workflows/*.yml` is named in `SECURITY.md`). Both inventories are hand-maintained and both have drifted — the workflow list twice. |

Path filters gain `learn/**`, `teardowns/**`, `docs/llms.txt`, `SECURITY.md` and the whole workflows directory. An edit under `learn/` previously triggered no docs-consistency run at all.

## Merge order

**Merge the discovery PR first.** The two class-closer jobs are written to catch the exact defects that PR fixes, so they fail on `main` as it stands and go green once it lands. Proof of both states below.

## Prerequisite

The `link-rot` label must exist in the repo before the next scheduled link-check failure, or `create-issue-from-file` will error when it tries to apply it. One-off: `gh label create link-rot`.

## Checks run locally

Every inline job script was extracted from the YAML and run against the working tree.

| Job | Against `main` | Against the discovery branch |
|---|---|---|
| `pattern-count` | pass — 18 / 'eighteen' | — |
| `role-count` | pass — 17 / 'seventeen' | — |
| `pattern-partition` | pass — 7 modules partition all 18 patterns, no duplicates | — |
| `llms-txt-coverage` | **fails as designed** — `teardowns/2026-09-06-azure-gpt-rag.md` unreferenced | pass — all 14 pages referenced |
| `security-workflow-inventory` | **fails as designed** — `freshness-check` not named | pass — all 10 workflows named |

| Other check | Result |
|---|---|
| `yaml.safe_load` on all three touched workflows | parses; docs-consistency exposes 5 jobs |
| `python scripts/validate_samples.py` | pass (51 sample files) |
| `python scripts/gen_llms_full.py --check` | pass (README is a source; regenerated) |
| `python scripts/check_freshness.py` | pass (README and sitemap stamps refreshed with `--fix`) |
| `python tools/workspace_check.py --self-test` | pass (12 checks) |
| Redaction grep over the full diff | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
